### PR TITLE
Change effective-date from dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'bootstrap-sass', '~> 3.0.3'
 gem 'sass-rails', "~> 4.0.2"
 gem 'coffee-rails'
 gem 'jquery-rails' # necessary for jquery_ujs w/data-method="delete" etc
+gem 'bootstrap-datepicker-rails', '1.3.0.2'
 gem 'uglifier'
 gem 'non-stupid-digest-assets' # support vendored non-digest assets
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.1.2'
-gem 'quality-measure-engine', '3.1.1'
+gem 'quality-measure-engine', '3.1.2'
 gem "hqmf2js", :git=> "https://github.com/pophealth/hqmf2js.git"
-gem 'health-data-standards', '3.5.0'
+gem 'health-data-standards', '3.5.3'
 #gem 'health-data-standards', :path=> '../health-data-standards'
 gem 'nokogiri'
 gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       multi_json
       sprockets (>= 2.0.3)
       tilt
-    health-data-standards (3.5.0)
+    health-data-standards (3.5.3)
       activesupport (~> 4.1.1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
@@ -169,7 +169,7 @@ GEM
     pry-byebug (1.3.3)
       byebug (~> 2.7)
       pry (~> 0.10)
-    quality-measure-engine (3.1.1)
+    quality-measure-engine (3.1.2)
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
       moped (~> 2.0.0)
@@ -194,7 +194,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.3.2)
-    rdoc (4.1.2)
+    rdoc (4.2.0)
       json (~> 1.4)
     ref (1.0.5)
     rest-client (1.6.8)
@@ -273,7 +273,7 @@ DEPENDENCIES
   formtastic
   git
   handlebars_assets
-  health-data-standards (= 3.5.0)
+  health-data-standards (= 3.5.3)
   highline
   hqmf2js!
   hquery-patient-api (= 1.0.4)
@@ -289,7 +289,7 @@ DEPENDENCIES
   protected_attributes (~> 1.0.5)
   pry
   pry-byebug
-  quality-measure-engine (= 3.1.1)
+  quality-measure-engine (= 3.1.2)
   rails (~> 4.1.2)
   rubyzip
   sass-rails (~> 4.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       json
     arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
+    bootstrap-datepicker-rails (1.3.0.2)
+      railties (>= 3.0)
     bootstrap-sass (3.0.3.0)
       sass (~> 3.2)
     bson (2.3.0)
@@ -261,6 +263,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (= 0.8.1)
   apipie-rails
+  bootstrap-datepicker-rails (= 1.3.0.2)
   bootstrap-sass (~> 3.0.3)
   cancan
   coffee-rails

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -1,5 +1,6 @@
 #= require jquery/jquery
 #= require jquery_ujs
+#= require bootstrap-datepicker
 #= require jquery-idletimer/dist/idle-timer
 #= require jQuery-Knob/js/jquery.knob
 #= require jquery-placeholder/jquery.placeholder

--- a/app/assets/javascripts/config.js.coffee.erb
+++ b/app/assets/javascripts/config.js.coffee.erb
@@ -2,7 +2,5 @@
   idleTimeout:
     isEnabled: <%= APP_CONFIG['idle_timeout_enabled'] %>
     timer: <%= APP_CONFIG['idle_timeout'] %>
-  # FIXME don't hard-code effective date
-  effectiveDate: 1356998340
   fieldValues: <%= HQMF::DataCriteria::FIELDS.to_json.html_safe %>
   ehExclusionType: <%= APP_CONFIG['eh_exclusion_type'].to_json %>

--- a/app/assets/javascripts/models/category.js.coffee
+++ b/app/assets/javascripts/models/category.js.coffee
@@ -1,11 +1,14 @@
 class Thorax.Models.Category extends Thorax.Model
   parse: (attrs) ->
     attrs = $.extend {}, attrs
-    attrs.measures = new Thorax.Collections.Measures attrs.measures, parent: this, parse: true
+    @effectiveDate = @collection?.effectiveDate #|| attrs.effectiveDate
+    attrs.measures = new Thorax.Collections.Measures attrs.measures, parent: this, parse: true #, effectiveDate: effectiveDate
     attrs
 
 class Thorax.Collections.Categories extends Thorax.Collection
   model: Thorax.Models.Category
+  initialize: (models, options) ->
+    @effectiveDate = options?.effectiveDate 
   comparator: (a, b) ->
     if a.get('category') is 'Core'
       -1

--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -12,7 +12,6 @@ class Thorax.Models.User extends Thorax.Model
     d = new Date(@get('effective_date') *1000)
     date = if end == true then (d.getUTCMonth() + 1 ) + '/' + d.getUTCDate() + '/' + d.getUTCFullYear() else (d.getUTCMonth() + 1) + '/' + d.getUTCDate() + '/' + (d.getUTCFullYear()-1)
 
-
   setPopulationChartScale: (value) ->
     @get('preferences').population_chart_scaled_to_IPP = value
     @save()

--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -7,6 +7,12 @@ class Thorax.Models.User extends Thorax.Model
   populationChartScaledToIPP: -> @get('preferences').population_chart_scaled_to_IPP
   shouldDisplayProviderTree: -> @get('preferences').should_display_provider_tree
 
+  effectiveDateString: (end) ->
+    # if end is true, returns date string. else it returns date string from 1 year ago
+    d = new Date(@get('effective_date') *1000)
+    date = if end == true then (d.getUTCMonth() + 1 ) + '/' + d.getUTCDate() + '/' + d.getUTCFullYear() else (d.getUTCMonth() + 1) + '/' + d.getUTCDate() + '/' + (d.getUTCFullYear()-1)
+
+
   setPopulationChartScale: (value) ->
     @get('preferences').population_chart_scaled_to_IPP = value
     @save()

--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -2,7 +2,7 @@ window.PopHealth ||= {}
 class PopHealth.Router extends Backbone.Router
   initialize: ->
     # categories is defined globally in view
-    @categories = new Thorax.Collections.Categories PopHealth.categories, parse: true
+    @categories = new Thorax.Collections.Categories PopHealth.categories, parse: true, effectiveDate: PopHealth.currentUser.get 'effective_date'
     @view = new Thorax.LayoutView el: '#container'
 
   routes:

--- a/app/assets/javascripts/templates/providers/show.hbs
+++ b/app/assets/javascripts/templates/providers/show.hbs
@@ -6,7 +6,7 @@
 </script>
 
 <div class="effective-date pull-right row-inline">
-  <h5 class='effective-date-header'><b> Reporting Period:</b> {{startDate}} &mdash; <input type="text" class="effective-date-picker"/> <button class="effective-date-btn btn-primary"> <i class="glyphicon glyphicon-refresh"/></button>
+  <h5 class='effective-date-header'><b> Reporting Period:</b> {{startDate}} &mdash; <input type="text" class="effective-date-picker" placeholder='mm/dd/yyyy' /> <button class="effective-date-btn btn-primary"> <i class="glyphicon glyphicon-refresh"/></button>
   </h5>
 </div> 
 <h2>{{providerType}} {{providerExtension}} {{title}} {{given_name}} {{family_name}}</h2>

--- a/app/assets/javascripts/templates/providers/show.hbs
+++ b/app/assets/javascripts/templates/providers/show.hbs
@@ -1,5 +1,14 @@
+<script type="text/javascript">		
+	$(document).ready(function(){
+    $('.effective-date-picker').datepicker({orientation: "top right", format: "m/d/yyyy"});
+    $(".effective-date-picker").val(PopHealth.currentUser.effectiveDateString(true));
+	});
+</script>
 
-
+<div class="effective-date pull-right row-inline">
+  <h5 class='effective-date-header'><b> Reporting Period:</b> {{startDate}} &mdash; <input type="text" class="effective-date-picker"/> <button class="effective-date-btn btn-primary"> <i class="glyphicon glyphicon-refresh"/></button>
+  </h5>
+</div> 
 <h2>{{providerType}} {{providerExtension}} {{title}} {{given_name}} {{family_name}}</h2>
 
 <h4>{{specialty}}</h4>

--- a/app/assets/javascripts/templates/providers/show.hbs
+++ b/app/assets/javascripts/templates/providers/show.hbs
@@ -1,8 +1,8 @@
 <script type="text/javascript">		
-	$(document).ready(function(){
+  $(document).ready(function(){
     $('.effective-date-picker').datepicker({orientation: "top right", format: "m/d/yyyy"});
     $(".effective-date-picker").val(PopHealth.currentUser.effectiveDateString(true));
-	});
+  });
 </script>
 
 <div class="effective-date pull-right row-inline">

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -87,7 +87,7 @@ class Thorax.Views.Dashboard extends Thorax.View
     @populationChartScaledToIPP = PopHealth.currentUser.populationChartScaledToIPP()
 
   effective_date: ->
-    Config.effectiveDate
+    PopHealth.currentUser.get 'effective_date'
 
   categoryFilterContext: (category) ->
     selectedCategory = @selectedCategories.findWhere(category: category.get('category'))

--- a/app/assets/javascripts/views/measure.js.coffee
+++ b/app/assets/javascripts/views/measure.js.coffee
@@ -1,7 +1,7 @@
 class SubmeasureView extends Thorax.View
   template: JST['measures/submeasure']
   context: ->
-    _(super).extend measurementPeriod: moment(Config.effectiveDate * 1000).format('YYYY')
+    _(super).extend measurementPeriod: moment(PopHealth.currentUser.get 'effective_date' * 1000).format('YYYY')
   logicIsActive: -> @parent.logicIsActive()
   patientResultsIsActive: -> @parent.patientResultsIsActive()
 
@@ -18,7 +18,7 @@ class Thorax.Views.MeasureView extends Thorax.LayoutView
     @submeasureView = new SubmeasureView model: @submeasure, provider_id: @provider_id
 
   context: ->
-    _(super).extend @submeasure.toJSON(), measurementPeriod: moment(Config.effectiveDate * 1000).format('YYYY')
+    _(super).extend @submeasure.toJSON(), measurementPeriod: moment(PopHealth.currentUser.get 'effective_date' * 1000).format('YYYY')
 
   changeFilter: (submeasure, population) ->
     if submeasure isnt @submeasure

--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -1,7 +1,7 @@
 class Thorax.Views.ProviderView extends Thorax.View
   template: JST['providers/show']
   initialize: ->
-    @dashboardView = new Thorax.Views.Dashboard provider_id: @model.id, collection: new Thorax.Collections.Categories PopHealth.categories, parse: true
+    @dashboardView = new Thorax.Views.Dashboard provider_id: @model.id, collection: new Thorax.Collections.Categories PopHealth.categories, parse: true, effectiveDate: PopHealth.currentUser.get 'effective_date'
     if PopHealth.currentUser.shouldDisplayProviderTree() then @providerChart = PopHealth.viz.providerChart()
     @startDate = PopHealth.currentUser.effectiveDateString(false)
   context: ->

--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -20,13 +20,7 @@ class Thorax.Views.ProviderView extends Thorax.View
   setEffectiveDate: (e) ->
     effectiveDate = $(".effective-date-picker").val()
     user = PopHealth.currentUser.get 'username'
-    $.ajax {
-      type: "POST",
-      url: "home/set_reporting_period",
-      data: {"effective_date": effectiveDate, "username": user}
-      success: (d) -> location.reload()
-    }    
-
+    $.post "home/set_reporting_period", {"effective_date": effectiveDate, "username": user}, (d) -> location.reload()
 
 # Layout for provider index; includes search bar and provider table
 class Thorax.Views.ProvidersView extends Thorax.View

--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -3,11 +3,13 @@ class Thorax.Views.ProviderView extends Thorax.View
   initialize: ->
     @dashboardView = new Thorax.Views.Dashboard provider_id: @model.id, collection: new Thorax.Collections.Categories PopHealth.categories, parse: true
     if PopHealth.currentUser.shouldDisplayProviderTree() then @providerChart = PopHealth.viz.providerChart()
+    @startDate = PopHealth.currentUser.effectiveDateString(false)
   context: ->
     _(super).extend
       providerType: @model.providerType() || ""
       providerExtension: @model.providerExtension() || ""
   events:
+    'click .effective-date-btn' : 'setEffectiveDate'
     rendered: ->
       if @model.isPopulated()
         d3.select(@el).select("#providerChart").datum(@model.toJSON()).call(@providerChart)
@@ -15,6 +17,15 @@ class Thorax.Views.ProviderView extends Thorax.View
     model:
       change: ->
           @dashboardView.filterEHMeasures(@model.providerType() == Config.ehExclusionType)
+  setEffectiveDate: (e) ->
+    effectiveDate = $(".effective-date-picker").val()
+    user = PopHealth.currentUser.get 'username'
+    $.ajax {
+      type: "POST",
+      url: "home/set_reporting_period",
+      data: {"effective_date": effectiveDate, "username": user}
+      success: (d) -> location.reload()
+    }    
 
 
 # Layout for provider index; includes search bar and provider table

--- a/app/assets/stylesheets/_bootstrap3.scss
+++ b/app/assets/stylesheets/_bootstrap3.scss
@@ -70,6 +70,39 @@ $font-family-sans-serif: "Helvetica Neue", Roboto, Helvetica, Arial, sans-serif;
 }
 
 
+// Datepicker custom <!--
+.datepicker{
+  margin-top: 5px;
+  padding-left: 5px;
+  padding-right: 5px;
+  
+  border-radius: 0px;
+  
+  th.datepicker-switch {
+    border-radius: 0px;    
+  }
+  th.prev {
+    border-radius: 0px;    
+  }
+  th.next {
+    border-radius: 0px;    
+  }
+  table tr td.day:hover,
+  table tr td.day.focused {
+    border-radius: 0px;
+  }
+  
+  .datepicker-days table tr td.active,
+  .datepicker-days table tr td.active:hover,
+  .datepicker-days table tr td.active.disabled,
+  .datepicker-days table tr td.active.disabled:hover {
+    border-radius: 0px;
+    background-color: $brand-primary;
+    background-image: -moz-linear-gradient(top, $brand-primary, $brand-primary);
+    background-image: -webkit-linear-gradient(top, $brand-primary, $brand-primary);
+  }
+}  
+// Datepicker Custom -->
 
 // Custom styles on HTML tags that are part of the theme
 

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -4,6 +4,29 @@ $title-circle-radius: 21px;
 
 // Custom styles that are part of the theme
 
+.dropdown {
+  position: relative;
+  z-index: 1000;
+}
+.effective-date-header{
+  font-size: 16px;
+}
+.effective-date-picker {
+  width: 100px;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 400;
+  height: 28px;
+  position: relative;
+  z-index: 100;
+}
+.effective-date-btn{
+  border: 0;
+  height: 28px;
+  width: 30px;
+  padding-left: 5px;
+}
+
 body {
   margin-bottom: 40px;
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,3 +1,4 @@
+@import "bootstrap-datepicker3";
 @import "variables";
 
 // 3rd party resources

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   layout :layout_by_resource
-  before_filter :set_effective_date
+  # before_filter :set_effective_date
   before_filter :check_ssl_used
 
   # lock it down!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   layout :layout_by_resource
-  # before_filter :set_effective_date
   before_filter :check_ssl_used
 
   # lock it down!

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,9 +11,16 @@ class HomeController < ApplicationController
     user = User.where(username: params[:username]).first
     unless params[:effective_date] == nil || params[:effective_date] == '' 
       month, day, year = params[:effective_date].split('/')
-      effective_date = Time.gm(year.to_i, month.to_i, day.to_i).to_i
+      if year.length == 2
+        year = "20" + year
+      end
+      begin
+        effective_date = Time.gm(year.to_i, month.to_i, day.to_i).to_i
+      rescue
+        render :json => :set_reporting_period, status: 200
+      end
       user.effective_date = effective_date
-      user.save! 
+      user.save!
     end
     render :json => :set_reporting_period, status: 200
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -15,7 +15,7 @@ class HomeController < ApplicationController
       user.effective_date = effective_date
       user.save! 
     end
-    render :json => :set_reporting_period
+    render :json => :set_reporting_period, status: 200
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,17 @@ class HomeController < ApplicationController
     @categories = HealthDataStandards::CQM::Measure.categories([:lower_is_better, :type])
   end
 
+  def set_reporting_period
+    user = User.where(username: params[:username]).first
+    unless params[:effective_date] == nil || params[:effective_date] == '' 
+      month, day, year = params[:effective_date].split('/')
+      effective_date = Time.gm(year.to_i, month.to_i, day.to_i).to_i
+      user.effective_date = effective_date
+      user.save! 
+    end
+    render :json => :set_reporting_period
+  end
+
   private
   def validate_authorization!
     authorize! :read, HealthDataStandards::CQM::Measure

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User
   field :npi, :type => String
   field :tin, :type => String
   field :agree_license, type: Boolean
-  field :effective_date, type: Integer, default: DEFAULT_EFFECTIVE_DATE
+  field :effective_date, type: Integer, default: DEFAULT_EFFECTIVE_DATE.to_i
   field :admin, type: Boolean
   field :approved, type: Boolean
   field :staff_role, type: Boolean

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User
   before_save :denullify_arrays
   before_create :set_defaults
 
-  DEFAULT_EFFECTIVE_DATE = Time.gm(2011, 1, 1)
+  DEFAULT_EFFECTIVE_DATE = Time.gm(2013, 12, 31)
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :authentication_keys => [:username]
@@ -55,7 +55,7 @@ class User
   field :npi, :type => String
   field :tin, :type => String
   field :agree_license, type: Boolean
-  field :effective_date, type: Integer
+  field :effective_date, type: Integer, default: DEFAULT_EFFECTIVE_DATE
   field :admin, type: Boolean
   field :approved, type: Boolean
   field :staff_role, type: Boolean

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="collapse navbar-collapse in">
       <ul class="nav navbar-nav pull-left" style="margin-top: 10px">
-        <li class="location"><% if Provider.root %><%= Provider.root.given_name %><% else %><%= APP_CONFIG['practice_name'] %><% end %> <span class="time"> 2012</span></li>
+        <li class="location"><% if Provider.root %><%= Provider.root.given_name %><% else %><%= APP_CONFIG['practice_name'] %><% end %></li>
       </ul>
        <ul class="nav pull-right">
         <li class="divider-vertical"></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ PopHealth::Application.routes.draw do
   post 'api/measures/finalize'
   post 'api/measures/update_metadata'
   get "logs/index"
+  post 'home/set_reporting_period'
 
   root :to => 'home#index'
 

--- a/spec/javascripts/views/dashboard_view.spec.js.coffee
+++ b/spec/javascripts/views/dashboard_view.spec.js.coffee
@@ -2,7 +2,7 @@ describe 'Dashboard', ->
   beforeEach ->
     json = loadJSONFixtures 'categories.json', 'users.json'
     window.PopHealth.currentUser = new Thorax.Models.User $.extend(true, {}, json['users.json'][0])
-    @categories = new Thorax.Collections.Categories json['categories.json'], parse: true
+    @categories = new Thorax.Collections.Categories json['categories.json'], parse: true, effectiveDate: json['users.json'][0].effective_date
     @view = new Thorax.Views.Dashboard collection: @categories
     @view.render()
 
@@ -14,7 +14,7 @@ describe 'Results View', ->
     json = loadJSONFixtures 'query.json', 'queries/patient_results.json', 'users.json', 'submeasure.json'
     window.PopHealth.currentUser = new Thorax.Models.User $.extend(true, {}, json['users.json'][0])
     @providerId = json['queries/patient_results.json'][0].value.provider_performances[0].provider_id
-    submeasure = new Thorax.Models.Submeasure json['submeasure.json'], parse: true
+    submeasure = new Thorax.Models.Submeasure json['submeasure.json'], parse: true, effectiveDate: json['users.json'][0].effective_date
     @query = new Thorax.Models.Query $.extend(true, {}, json['query.json']), {parent: submeasure}
     @measureId = @query.get('measure_id')
     @resultsViewWithProvider = new Thorax.Views.ResultsView model: @query, id: @measureId, provider_id: @providerId

--- a/spec/javascripts/views/query_view.spec.js.coffee
+++ b/spec/javascripts/views/query_view.spec.js.coffee
@@ -6,7 +6,7 @@ describe 'QueryView', ->
     jasmine.Ajax.install()
     @json = getJSONFixture 
     submeasure = new Thorax.Models.Submeasure json['submeasure.json'], parse: true
-    @query = new Thorax.Models.Query {measure_id: submeasure.get('id'), sub_id: submeasure.get('sub_id'), effective_date: Config.effectiveDate}, parent: submeasure
+    @query = new Thorax.Models.Query {measure_id: submeasure.get('id'), sub_id: submeasure.get('sub_id'), effective_date: json['users.json'][0].effective_date}, parent: submeasure
     @queryView = new Thorax.Views.QueryView model: @query
     # respond to all query requests, as there will be several views with the query as its model
     queryJson = json['query.json']

--- a/test/functional/home_controller_test.rb
+++ b/test/functional/home_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+include Devise::TestHelpers
+
+class HomeControllerTest < ActionController::TestCase
+
+  setup  do
+    dump_database
+    collection_fixtures 'users'
+    @admin = User.where({email: 'admin@test.com'}).first
+    @user = User.where({email: 'noadmin@test.com'}).first
+  end
+    
+  test "user can change reporting period" do
+    sign_in @user
+    time = Time.gm(2015,5,1).to_i
+    post "set_reporting_period", username: @user.username, effective_date: '05/01/2015'
+    assert_response :success
+  end
+  
+  test "default effective date for new user" do
+    sign_in @admin
+    time = Time.gm(2013,12,31).to_i
+    user = User.new    
+    assert_equal time, user.effective_date  
+  end
+end

--- a/test/unit/models/user_test.rb
+++ b/test/unit/models/user_test.rb
@@ -41,4 +41,11 @@ class UserTest < ActiveSupport::TestCase
     assert_response :success
     assert_equal @user.effective_date, time  
   end
+  
+  test "default effective date for new user"
+    sign_in User.where({email: "admin@test.com"}).first
+    time = Time.gm(2013,12,31)
+    user = User.new    
+    assert_equal time, user.effective_date  
+  end
 end

--- a/test/unit/models/user_test.rb
+++ b/test/unit/models/user_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  include Devise::TestHelpers
 
   setup do
     dump_database
@@ -31,5 +32,13 @@ class UserTest < ActiveSupport::TestCase
     assert @user.save
     @user.reload
     assert_equal true, @user.preferences['should_display_provider_tree']
+  end
+  
+  test "user can change reporting period"
+    sign_in @user
+    time = Time.gm(2013,12,31)
+    post "home/set_reporting_period", effective_date: time
+    assert_response :success
+    assert_equal @user.effective_date, time  
   end
 end

--- a/test/unit/models/user_test.rb
+++ b/test/unit/models/user_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  include Devise::TestHelpers
 
   setup do
     dump_database
@@ -32,20 +31,5 @@ class UserTest < ActiveSupport::TestCase
     assert @user.save
     @user.reload
     assert_equal true, @user.preferences['should_display_provider_tree']
-  end
-  
-  test "user can change reporting period"
-    sign_in @user
-    time = Time.gm(2013,12,31)
-    post "home/set_reporting_period", effective_date: time
-    assert_response :success
-    assert_equal @user.effective_date, time  
-  end
-  
-  test "default effective date for new user"
-    sign_in User.where({email: "admin@test.com"}).first
-    time = Time.gm(2013,12,31)
-    user = User.new    
-    assert_equal time, user.effective_date  
   end
 end


### PR DESCRIPTION
Added: 
- A date-picker on provider dashboards that allows the user to change the reporting periond end-date. popHealth currently supports a 1 year reporting window.