### PR TITLE
Upgrade HDS and QME to latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 4.1.2'
-gem 'quality-measure-engine', '3.1.1'
+gem 'quality-measure-engine', '3.1.2'
 gem "hqmf2js", :git=> "https://github.com/pophealth/hqmf2js.git"
-gem 'health-data-standards', '3.5.0'
+gem 'health-data-standards', '3.5.3'
 #gem 'health-data-standards', :path=> '../health-data-standards'
 gem 'nokogiri'
 gem 'rubyzip'


### PR DESCRIPTION
Updated QME to 3.1.2 and HDS to 3.5.3.

Currently running CMS117 will cause MongoDB to go to 100% CPU and then crash. Developers are looking into resolving this issue.