### PR TITLE
Appropriately handle when practices have no provider

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -64,7 +64,7 @@ class PracticesController < ApplicationController
   def destroy
     @practice = Practice.find(params[:id])
     Record.where(practice_id: @practice.id).delete
-    Provider.where(parent_id: @practice.provider.id).delete
+    Provider.where(parent_id: @practice.provider.id).delete if @practice.provider
     @practice.destroy
 
     respond_to do |format|

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -25,7 +25,7 @@
         <td><%= practice.address %></td> 
         <td><%= practice.users ? practice.users.map {|u| u.username}.join(", ") : 'N/A' %></td>                
         <td><%= practice.records ? practice.records.count : 0 %></td>
-        <td><%= practice.provider.descendants.count %></td>
+        <td><%= practice.provider ? practice.provider.descendants.count : 0 %></td>
         <td><%= link_to "Delete Patients", practices_remove_patients_path(id: practice.id), method: :delete, data: { confirm: 'Are you sure you want to delete all patients for ' + "#{practice.name}?"} %></td>
         <td><%= link_to 'Delete Practice', practice, method: :delete, data: { confirm: 'Are you sure? There may be patients tied to this practice' } %></td>
       </tr>


### PR DESCRIPTION
When testing with the new multi-practices feature, I came across a few exceptions where the provider collection was empty and caused the app to crash.