### PR TITLE
Aggregate measure calculation - practice mode

### DIFF
--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -20,7 +20,14 @@ _.extend PopHealth.Helpers,
     else
       return value
 
-
+  formatNumber: (value) ->
+    return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ",") unless isNaN(value)
+    
+  formatMRN: (mrn) ->
+    if mrn
+      length = if mrn.indexOf("-") is -1 then mrn.length-1 else mrn.indexOf("-")
+      return mrn.substring(0, length)
+    
 ##### Handlebars Helpers
 Handlebars.registerHelper 'join', (list, options = {}) ->
   mappable = if list instanceof Backbone.Collection then list else _(list)

--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -19,9 +19,6 @@ _.extend PopHealth.Helpers,
       return value.replace(/[MD]/g, 'x')
     else
       return value
-
-  formatNumber: (value) ->
-    return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ",") unless isNaN(value)
     
   formatMRN: (mrn) ->
     if mrn

--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -22,7 +22,7 @@ _.extend PopHealth.Helpers,
     
   formatMRN: (mrn) ->
     if mrn
-      length = if mrn.indexOf("-") is -1 then mrn.length-1 else mrn.indexOf("-")
+      length = if mrn.indexOf("_pid_") is -1 then mrn.length-1 else mrn.indexOf("_pid_")
       return mrn.substring(0, length)
     
 ##### Handlebars Helpers

--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -45,6 +45,7 @@ class Thorax.Models.Entry extends Thorax.Model
     attrs = $.extend {}, attrs
     attrs.start_time *= 1000
     attrs.end_time *= 1000
+    attrs.time *= 1000
     if attrs.values
       attrs.values = new Thorax.Collection attrs.values
     attrs

--- a/app/assets/javascripts/models/patient_result.js.coffee
+++ b/app/assets/javascripts/models/patient_result.js.coffee
@@ -15,6 +15,8 @@ class Thorax.Collections.PatientMeasureResults extends Thorax.Collection
 class Thorax.Collections.PatientResults extends Thorax.Collection
   model: Thorax.Models.PatientResult
   url: -> "#{@parent.url()}/patient_results"
+  comparator: (p) ->
+    [p.get("last"), p.get("first")]
   initialize: (attrs, options) ->
     @parent = options.parent
     @population = options.population

--- a/app/assets/javascripts/models/query.js.coffee
+++ b/app/assets/javascripts/models/query.js.coffee
@@ -21,7 +21,7 @@ class Thorax.Models.Query extends Thorax.Model
   outliers: -> if @isPopulated() and @has('result') then @get('result').antinumerator else 0
   performanceDenominator: -> @denominator() - @exceptions() - @exclusions()
   performanceRate: -> Math.round(100 * @numerator() / Math.max(1, @performanceDenominator()))
-
+  aggregateResult: -> if @isPopulated() then @get('aggregate_result') else 0
   # hack so that creating a query acts just like checking an existing query
   fetch: -> if @isNew() then @save() else super(arguments...)
   result: -> _(@get('result')).extend performanceDenominator: @performanceDenominator()

--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -6,6 +6,11 @@ class Thorax.Models.User extends Thorax.Model
   shouldDisplayPercentageVisual: -> @get('preferences').should_display_circle_visual
   populationChartScaledToIPP: -> @get('preferences').population_chart_scaled_to_IPP
   shouldDisplayProviderTree: -> @get('preferences').should_display_provider_tree
+  showAggregateResult: -> @get('preferences').show_aggregate_result
+ 
+  setShowAggregateResult: (value) -> 
+    @get('preferences').show_aggregate_result = value
+    @save()
 
   effectiveDateString: (end) ->
     # if end is true, returns date string. else it returns date string from 1 year ago

--- a/app/assets/javascripts/templates/dashboard/index.hbs.erb
+++ b/app/assets/javascripts/templates/dashboard/index.hbs.erb
@@ -1,5 +1,10 @@
 <div class="sidebar" id="filters">
   <h3>Filters</h3>
+  {{#unless opml}}
+  <span class="panel-title btn btn-checkbox btn-block aggregate-btn {{#if showAggregateResult}}active{{/if}}"> 
+    <i class="fa fa-group"/> &nbsp; SHOW AGGREGATE RESULT 
+  </span>
+  {{/unless}}
 
   <p class="input-group">
     <input type="text" class="form-control category-measure-search" placeholder="measure or group title">

--- a/app/assets/javascripts/templates/dashboard/results.hbs
+++ b/app/assets/javascripts/templates/dashboard/results.hbs
@@ -20,3 +20,8 @@
 
   <a href="#measures/{{id}}{{#if sub_id}}/{{sub_id}}{{/if}}{{#if provider_id}}/providers/{{provider_id}}{{/if}}/patient_results" class="patient-btn pull-right">Patients</a>
 </div>
+
+<div class='pull-right aggregate-result'>
+  <text id="aggregate-header"> Aggregate: &nbsp; </text> 
+  <b id='aggregate-value'> {{aggregateResult}} {{unit}} </b>
+</div>

--- a/app/assets/javascripts/templates/dashboard/submeasure.hbs
+++ b/app/assets/javascripts/templates/dashboard/submeasure.hbs
@@ -24,4 +24,4 @@
   </div>
   {{view "ResultsView" model=query id=id sub_id=sub_id episode_of_care=episode_of_care lower_is_better=lower_is_better provider_id=provider_id}}
 </div>
-<div class="pull-left {{id}}-loading-measure"></div>
+<div class="pull-left {{id}}{{#if sub_id}}{{sub_id}}{{/if}}-loading-measure" hidden="true"><h2>LOADING...</h2></div>

--- a/app/assets/javascripts/templates/dashboard/submeasure.hbs
+++ b/app/assets/javascripts/templates/dashboard/submeasure.hbs
@@ -24,3 +24,4 @@
   </div>
   {{view "ResultsView" model=query id=id sub_id=sub_id episode_of_care=episode_of_care lower_is_better=lower_is_better provider_id=provider_id}}
 </div>
+<div class="pull-left {{id}}-loading-measure"></div>

--- a/app/assets/javascripts/templates/patient_results/index.hbs
+++ b/app/assets/javascripts/templates/patient_results/index.hbs
@@ -13,7 +13,7 @@
   <tr>
     <td>{{#link "patients/{{patient_id}}" expand-tokens=true}}{{last}}{{/link}}</td>
     <td>{{first}}</td>
-    <td class="col-patient-medical-record-id" title="{{medical_record_id}}">{{medical_record_id}}</td>
+    <td class="col-patient-medical-record-id" title="{{medical_record_id}}">{{mrn}}</td>
     <td>{{age}}</td>
     <td>{{formatted_birthdate}}</td>
     <td>{{gender}}</td>

--- a/app/assets/javascripts/templates/patient_results/query_buttons.hbs
+++ b/app/assets/javascripts/templates/patient_results/query_buttons.hbs
@@ -1,30 +1,30 @@
 <button class="population-btn{{#if ippIsActive}} active{{/if}}" data-population="IPP">
   <span class="title">Initial Patient Pop.</span>
-  <span class="query-result">{{ipp}}</span>
+  <span class="query-result">{{formatNumeral ipp "0,0"}}</span>
 </button>
 <button class="population-btn{{#if numeratorIsActive}} active{{/if}}" data-population="NUMER">
   <span class="title">Numerator</span>
-  <span class="query-result">{{numerator}}</span>
+  <span class="query-result">{{formatNumeral numerator "0,0"}}</span>
 </button>
 <button class="population-btn{{#if denominatorIsActive}} active{{/if}}" data-population="DENOM">
   <span class="title">Denominator</span>
-  <span class="query-result">{{denominator}}</span>
+  <span class="query-result">{{formatNumeral denominator "0,0"}}</span>
 </button>
 {{#if hasExclusions}}
 <button class="population-btn{{#if exclusionsAreActive}} active{{/if}}" data-population="DENEX">
   <span class="title">Exclusions</span>
-  <span class="query-result">{{exclusions}}</span>
+  <span class="query-result">{{formatNumeral exclusions "0,0"}}</span>
 </button>
 {{/if}}
 {{#if hasExceptions}}
 <button class="population-btn{{#if exceptionsAreActive}} active{{/if}}" data-population="DENEXCEP">
   <span class="title">Exceptions</span>
-  <span class="query-result">{{exceptions}}</span>
+  <span class="query-result">{{formatNumeral exceptions "0,0"}}</span>
 </button>
 {{/if}}
 {{#if hasOutliers}}
 <button class="population-btn{{#if antinumeratorIsActive}} active{{/if}}" data-population="antinumerator">
   <span class="title">Outliers</span>
-  <span class="query-result">{{outliers}}</span>
+  <span class="query-result">{{formatNumeral outliers "0,0"}}</span>
 </button>
 {{/if}}

--- a/app/assets/javascripts/templates/patient_results/query_heading.hbs
+++ b/app/assets/javascripts/templates/patient_results/query_heading.hbs
@@ -9,7 +9,7 @@
   <i class="{{#if episodeOfCare}}fa fa-stethoscope{{else}}glyphicon glyphicon-user{{/if}}"></i>
 </div>
 <div class="fraction-listing pull-left">
-  <div class="numerator">{{fractionTop}}</div>
-  <div class="denominator">{{fractionBottom}}</div>
+  <div class="numerator">{{formatNumeral fractionTop "0,0"}}</div>
+  <div class="denominator">{{formatNumeral fractionBottom "0,0"}}</div>
 </div>
 <div class="pop-chart pull-left"></div>

--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -41,7 +41,7 @@
       <div class="patient-data-list">
         <dl class="dl-horizontal">
           <dt>PATIENT ID</dt>
-          <dd><div class="patient-medical-record-id" title="{{medical_record_number}}">{{medical_record_number}}</div></dd>
+          <dd><div class="patient-medical-record-id" title="{{mrn}}">{{mrn}}</div></dd>
           <dt>DOB</dt>
           <dd>{{birthdate}}</dd>
           <dt>GENDER</dt>
@@ -107,7 +107,7 @@
             </dl>
             <dl class="dl-horizontal">
               <dt>date</dt>
-              <dd>{{start_time}}{{#if display_end_time}} &ndash; {{end_time}}{{/if}}</dd>
+              <dd>{{#if start_time}} {{start_time}} {{else}} {{time_format}} {{/if}} {{#if display_end_time}} &ndash; {{end_time}}{{/if}}</dd>
             </dl>
           </div>
         </div>

--- a/app/assets/javascripts/templates/providers/show.hbs
+++ b/app/assets/javascripts/templates/providers/show.hbs
@@ -10,7 +10,7 @@
   </h5>
 </div> 
 <h2>{{providerType}}: {{providerExtension}}, {{title}} {{given_name}} {{family_name}}</h2>
-<h2># of Patients: {{patient_count_format}} </dd> </h2>
+<h2># of Patients: {{formatNumeral patient_count "0,0"}} </dd> </h2>
 
 <h4>{{specialty}}</h4>
 <h4>{{organization.name}}</h4>

--- a/app/assets/javascripts/templates/providers/show.hbs
+++ b/app/assets/javascripts/templates/providers/show.hbs
@@ -10,7 +10,7 @@
   </h5>
 </div> 
 <h2>{{providerType}}: {{providerExtension}}, {{title}} {{given_name}} {{family_name}}</h2>
-<h2># of Patients: {{patient_count}} </dd> </h2>
+<h2># of Patients: {{patient_count_format}} </dd> </h2>
 
 <h4>{{specialty}}</h4>
 <h4>{{organization.name}}</h4>

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -108,10 +108,14 @@ class Thorax.Views.Dashboard extends Thorax.View
   toggleAggregateShow: (e) ->    
     shown = PopHealth.currentUser.showAggregateResult()
     PopHealth.currentUser.setShowAggregateResult(!shown)
-    @$('.aggregate-result').toggle(400)   
-    @$('.aggregate-btn').toggleClass('active')
-    location.reload() if PopHealth.currentUser.showAggregateResult()
-    
+    if !shown 
+      if confirm "Please wait for the aggregate measure to calculate. The result will appear when the calculation is completed."
+        location.reload()
+        @$('.aggregate-result').toggle(400)   
+        @$('.aggregate-btn').toggleClass('active')
+    else
+      @$('.aggregate-result').toggle(400)   
+      @$('.aggregate-btn').toggleClass('active')
 
   effective_date: ->
     PopHealth.currentUser.get 'effective_date'

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -9,7 +9,7 @@ class Thorax.Views.ResultsView extends Thorax.View
   events:
     model:
       change: ->
-        if @model.isPopulated()
+        if (PopHealth.currentUser.showAggregateResult() and @model.aggregateResult()) or (!PopHealth.currentUser.showAggregateResult() and @model.isPopulated())
           clearInterval(@timeout) if @timeout?
           d3.select(@el).select('.pop-chart').datum(_(lower_is_better: @lower_is_better).extend @model.result()).call(@popChart)
         else

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -110,6 +110,8 @@ class Thorax.Views.Dashboard extends Thorax.View
     PopHealth.currentUser.setShowAggregateResult(!shown)
     @$('.aggregate-result').toggle(400)   
     @$('.aggregate-btn').toggleClass('active')
+    location.reload() if PopHealth.currentUser.showAggregateResult()
+    
 
   effective_date: ->
     PopHealth.currentUser.get 'effective_date'

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -45,6 +45,7 @@ class Thorax.Views.ResultsView extends Thorax.View
 
   authorize: ->
     @response = $.ajax({ 
+      async: false,
       url: "home/check_authorization/", 
       data: {"id": @provider_id}
     }).responseText    
@@ -58,7 +59,6 @@ class Thorax.Views.ResultsView extends Thorax.View
       fractionBottom: if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
       aggregateResult: @model.aggregateResult()
   initialize: ->
-    
     @popChart = PopHealth.viz.populationChart().width(125).height(25).maximumValue(PopHealth.patientCount)
     @model.set('providers', [@provider_id]) if @provider_id?
 

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -9,10 +9,13 @@ class Thorax.Views.ResultsView extends Thorax.View
   events:
     model:
       change: ->
+        loadingDiv = "." + String(@model.get('measure_id')) + "-loading-measure"
         if (PopHealth.currentUser.showAggregateResult() and @model.aggregateResult()) or (!PopHealth.currentUser.showAggregateResult() and @model.isPopulated())
+          $(loadingDiv).html("")
           clearInterval(@timeout) if @timeout?
           d3.select(@el).select('.pop-chart').datum(_(lower_is_better: @lower_is_better).extend @model.result()).call(@popChart)
         else
+          $(loadingDiv).html("<h2>LOADING...</h2>")
           @authorize()
           if @response == 'false'
             clearInterval(@timeout)

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -26,6 +26,7 @@ class Thorax.Views.ResultsView extends Thorax.View
           if PopHealth.currentUser.populationChartScaledToIPP() then @popChart.maximumValue(@model.result().IPP) else @popChart.maximumValue(PopHealth.patientCount)
           @popChart.update(_(lower_is_better: @lower_is_better).extend @model.result())
     rendered: ->
+      unless PopHealth.currentUser.showAggregateResult() then @$('.aggregate-result').hide()
       @$(".icon-popover").popover()
       @$('.dial').knob()
       if @model.isPopulated()
@@ -49,7 +50,7 @@ class Thorax.Views.ResultsView extends Thorax.View
       resultValue: if @model.isContinuous() then @model.observation() else @model.performanceRate()
       fractionTop: if @model.isContinuous() then @model.measurePopulation() else @model.numerator()
       fractionBottom: if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
-
+      aggregateResult: @model.aggregateResult()
   initialize: ->
     @popChart = PopHealth.viz.populationChart().width(125).height(25).maximumValue(PopHealth.patientCount)
     @model.set('providers', [@provider_id]) if @provider_id?
@@ -81,6 +82,7 @@ class Thorax.Views.DashboardSubmeasureView extends Thorax.View
 class Thorax.Views.Dashboard extends Thorax.View
   template: JST['dashboard/index']
   events:
+    'click .aggregate-btn': 'toggleAggregateShow'
     'click .btn-checkbox.all':           'toggleCategory'
     'click .btn-checkbox.individual':    'toggleMeasure'
     'keyup .category-measure-search': 'search'
@@ -100,6 +102,15 @@ class Thorax.Views.Dashboard extends Thorax.View
     @selectedCategories = PopHealth.currentUser.selectedCategories(@collection)
     @populationChartScaledToIPP = PopHealth.currentUser.populationChartScaledToIPP()
     @currentUser = PopHealth.currentUser.get 'username'
+    @showAggregateResult = PopHealth.currentUser.showAggregateResult()
+    @opml = PopHealth.OPML
+
+  toggleAggregateShow: (e) ->    
+    shown = PopHealth.currentUser.showAggregateResult()
+    PopHealth.currentUser.setShowAggregateResult(!shown)
+    @$('.aggregate-result').toggle(400)   
+    @$('.aggregate-btn').toggleClass('active')
+
   effective_date: ->
     PopHealth.currentUser.get 'effective_date'
 

--- a/app/assets/javascripts/views/dashboard.js.coffee
+++ b/app/assets/javascripts/views/dashboard.js.coffee
@@ -9,13 +9,17 @@ class Thorax.Views.ResultsView extends Thorax.View
   events:
     model:
       change: ->
-        loadingDiv = "." + String(@model.get('measure_id')) + "-loading-measure"
+        if @model.get('sub_id')
+          measureid = String(@model.get('measure_id')) + String(@model.get('sub_id'))
+        else
+          measureid = String(@model.get('measure_id')) 
+        loadingDiv = "." + measureid + "-loading-measure"
         if (PopHealth.currentUser.showAggregateResult() and @model.aggregateResult()) or (!PopHealth.currentUser.showAggregateResult() and @model.isPopulated())
-          $(loadingDiv).html("")
+          $(loadingDiv).hide()
           clearInterval(@timeout) if @timeout?
           d3.select(@el).select('.pop-chart').datum(_(lower_is_better: @lower_is_better).extend @model.result()).call(@popChart)
         else
-          $(loadingDiv).html("<h2>LOADING...</h2>")
+          $(loadingDiv).show()
           @authorize()
           if @response == 'false'
             clearInterval(@timeout)
@@ -41,7 +45,6 @@ class Thorax.Views.ResultsView extends Thorax.View
 
   authorize: ->
     @response = $.ajax({ 
-      async: false,
       url: "home/check_authorization/", 
       data: {"id": @provider_id}
     }).responseText    
@@ -55,6 +58,7 @@ class Thorax.Views.ResultsView extends Thorax.View
       fractionBottom: if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
       aggregateResult: @model.aggregateResult()
   initialize: ->
+    
     @popChart = PopHealth.viz.populationChart().width(125).height(25).maximumValue(PopHealth.patientCount)
     @model.set('providers', [@provider_id]) if @provider_id?
 

--- a/app/assets/javascripts/views/patient_results_view.js.coffee
+++ b/app/assets/javascripts/views/patient_results_view.js.coffee
@@ -26,7 +26,7 @@ class Thorax.Views.PatientResultsView extends Thorax.View
       last: PopHealth.Helpers.maskName(patient.get('last')) if patient.get('last')
       formatted_birthdate: moment(patient.get('birthdate')).format(PopHealth.Helpers.maskDateFormat('MM/DD/YYYY')) if patient.get('birthdate')
       age: moment(patient.get('birthdate')).fromNow().split(' ')[0] if patient.get('birthdate')
-
+      mrn: PopHealth.Helpers.formatMRN(patient.get('medical_record_id'))
   events:
     rendered: ->
       $(document).on 'scroll', @scrollHandler

--- a/app/assets/javascripts/views/patient_view.js.coffee
+++ b/app/assets/javascripts/views/patient_view.js.coffee
@@ -5,6 +5,7 @@ class Thorax.Views.PatientView extends Thorax.View
       @$('#measures').on 'show.bs.collapse hide.bs.collapse', (e) ->
         $(e.target).prev().toggleClass('active').find('.submeasure-expander .fa').toggleClass('fa-plus-square-o fa-minus-square-o')
   context: ->
+    mrn = if @model.get("medical_record_number") then PopHealth.Helpers.formatMRN(String(@model.get("medical_record_number"))) else 'N/A'
     _(super).extend
       first: PopHealth.Helpers.maskName @model.get('first')
       last: PopHealth.Helpers.maskName @model.get('last')
@@ -16,6 +17,7 @@ class Thorax.Views.PatientView extends Thorax.View
       languages: if _.isEmpty(@model.get('language_names')) then 'Not Available' else @model.get('language_names')
       provider: if @model.has('provider_name') then @model.get('provider_name') else 'Not Available'
       measures: @measures()
+      mrn: mrn
 
   measures: ->
     measures = new Thorax.Collection
@@ -36,6 +38,7 @@ class Thorax.Views.EntryView extends Thorax.View
     _(super).extend
       start_time: formatTime @model.get('start_time')
       end_time: formatTime @model.get('end_time') if @model.get('end_time')?
+      time_format: formatTime @model.get('time')  if @model.get('time')?
       display_end_time: @model.get('end_time') and (formatTime @model.get('start_time')) isnt (formatTime @model.get('end_time'))
       entry_type: @model.entryType
       icon: @model.icon

--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -5,10 +5,12 @@ class Thorax.Views.ProviderView extends Thorax.View
     if PopHealth.currentUser.shouldDisplayProviderTree() then @providerChart = PopHealth.viz.providerChart()
     @startDate = PopHealth.currentUser.effectiveDateString(false)
   context: ->
+    patient_count = if @model.get('patient_count') then PopHealth.Helpers.formatNumber(@model.get('patient_count')) else "N/A" 
     _(super).extend
       providerType: @model.providerType() || ""
       providerExtension: @model.providerExtension() || ""
       npi: @model.npi() || ""
+      patient_count_format: patient_count
   events:
     'click .effective-date-btn' : 'setEffectiveDate'
     rendered: ->

--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -5,12 +5,11 @@ class Thorax.Views.ProviderView extends Thorax.View
     if PopHealth.currentUser.shouldDisplayProviderTree() then @providerChart = PopHealth.viz.providerChart()
     @startDate = PopHealth.currentUser.effectiveDateString(false)
   context: ->
-    patient_count = if @model.get('patient_count') then PopHealth.Helpers.formatNumber(@model.get('patient_count')) else "N/A" 
     _(super).extend
       providerType: @model.providerType() || ""
       providerExtension: @model.providerExtension() || ""
       npi: @model.npi() || ""
-      patient_count_format: patient_count
+      patient_count: @model.get('patient_count')
   events:
     'click .effective-date-btn' : 'setEffectiveDate'
     rendered: ->

--- a/app/assets/javascripts/views/query_view.js.coffee
+++ b/app/assets/javascripts/views/query_view.js.coffee
@@ -11,8 +11,8 @@ class QueryHeadingView extends Thorax.View
     @popChart = PopHealth.viz.populationChart().width(125).height(25).maximumValue(PopHealth.patientCount)
   shouldDisplayPercentageVisual: -> !@model.isContinuous() and PopHealth.currentUser.shouldDisplayPercentageVisual()
   resultValue: -> if @model.isContinuous() then @model.observation() else @model.performanceRate()
-  fractionTop: -> if @model.isContinuous() then @model.measurePopulation() else @model.numerator()
-  fractionBottom: -> if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
+  fractionTop: -> if @model.isContinuous() then @model.measurePopulation() else PopHealth.Helpers.formatNumber(@model.numerator())
+  fractionBottom: -> if @model.isContinuous() then @model.ipp() else PopHealth.Helpers.formatNumber(@model.performanceDenominator())
   episodeOfCare: -> @model.parent.get('episode_of_care')
   unit: -> if @model.isContinuous() and @model.parent.get('cms_id') isnt 'CMS179v2' then 'min' else '%'
 
@@ -31,17 +31,17 @@ class QueryButtonsView extends Thorax.View
           , 3000
   initialize: ->
     @currentPopulation ?= 'IPP'
-  ipp: -> @model.ipp()
-  numerator: -> @model.numerator()
-  denominator: -> @model.denominator()
+  ipp: -> PopHealth.Helpers.formatNumber(@model.ipp())
+  numerator: -> PopHealth.Helpers.formatNumber(@model.numerator())
+  denominator: -> PopHealth.Helpers.formatNumber(@model.denominator()-@model.exclusions())
   hasExceptions: -> @model.hasExceptions()
-  exceptions: -> @model.exceptions()
+  exceptions: -> PopHealth.Helpers.formatNumber(@model.exceptions())
   hasExclusions: -> @model.hasExclusions()
-  exclusions: -> @model.exclusions()
+  exclusions: -> PopHealth.Helpers.formatNumber(@model.exclusions())
   hasOutliers: -> @model.hasOutliers()
-  outliers: -> @model.outliers()
+  outliers: -> PopHealth.Helpers.formatNumber(@model.outliers())
   performanceRate: -> @model.performanceRate()
-  performanceDenominator: -> @model.performanceDenominator()
+  performanceDenominator: -> PopHealth.Helpers.formatNumber(@model.performanceDenominator())
 
   ippIsActive: -> @isActive and @currentPopulation is 'IPP'
   numeratorIsActive: -> @isActive and @currentPopulation is 'NUMER'

--- a/app/assets/javascripts/views/query_view.js.coffee
+++ b/app/assets/javascripts/views/query_view.js.coffee
@@ -7,15 +7,16 @@ class QueryHeadingView extends Thorax.View
       if @model.isPopulated()
         @popChart.maximumValue(@model.result().IPP)
         d3.select(@el).select('.pop-chart').datum(@model.result()).call(@popChart)
+  context: ->
+    _(super).extend
+      shouldDisplayPercentageVisual: !@model.isContinuous() and PopHealth.currentUser.shouldDisplayPercentageVisual()
+      resultValue: if @model.isContinuous() then @model.observation() else @model.performanceRate()
+      fractionTop: if @model.isContinuous() then @model.measurePopulation() else @model.numerator()
+      fractionBottom: if @model.isContinuous() then @model.ipp() else @model.performanceDenominator()
+      episodeOfCare: @model.parent.get('episode_of_care')
+      unit: if @model.isContinuous() and @model.parent.get('cms_id') isnt 'CMS179v2' then 'min' else '%'
   initialize: ->
     @popChart = PopHealth.viz.populationChart().width(125).height(25).maximumValue(PopHealth.patientCount)
-  shouldDisplayPercentageVisual: -> !@model.isContinuous() and PopHealth.currentUser.shouldDisplayPercentageVisual()
-  resultValue: -> if @model.isContinuous() then @model.observation() else @model.performanceRate()
-  fractionTop: -> if @model.isContinuous() then @model.measurePopulation() else PopHealth.Helpers.formatNumber(@model.numerator())
-  fractionBottom: -> if @model.isContinuous() then @model.ipp() else PopHealth.Helpers.formatNumber(@model.performanceDenominator())
-  episodeOfCare: -> @model.parent.get('episode_of_care')
-  unit: -> if @model.isContinuous() and @model.parent.get('cms_id') isnt 'CMS179v2' then 'min' else '%'
-
 
 class QueryButtonsView extends Thorax.View
   template: JST['patient_results/query_buttons']
@@ -31,24 +32,26 @@ class QueryButtonsView extends Thorax.View
           , 3000
   initialize: ->
     @currentPopulation ?= 'IPP'
-  ipp: -> PopHealth.Helpers.formatNumber(@model.ipp())
-  numerator: -> PopHealth.Helpers.formatNumber(@model.numerator())
-  denominator: -> PopHealth.Helpers.formatNumber(@model.denominator()-@model.exclusions())
-  hasExceptions: -> @model.hasExceptions()
-  exceptions: -> PopHealth.Helpers.formatNumber(@model.exceptions())
-  hasExclusions: -> @model.hasExclusions()
-  exclusions: -> PopHealth.Helpers.formatNumber(@model.exclusions())
-  hasOutliers: -> @model.hasOutliers()
-  outliers: -> PopHealth.Helpers.formatNumber(@model.outliers())
-  performanceRate: -> @model.performanceRate()
-  performanceDenominator: -> PopHealth.Helpers.formatNumber(@model.performanceDenominator())
+  context: ->
+    _(super).extend 
+      ipp: @model.ipp()
+      numerator: @model.numerator()
+      denominator: @model.denominator()
+      hasExceptions: @model.hasExceptions()
+      exceptions: @model.exceptions()
+      hasExclusions: @model.hasExclusions()
+      exclusions: @model.exclusions()
+      hasOutliers: @model.hasOutliers()
+      outliers: @model.outliers()
+      performanceRate: @model.performanceRate()
+      performanceDenominator: @model.performanceDenominator()
 
-  ippIsActive: -> @isActive and @currentPopulation is 'IPP'
-  numeratorIsActive: -> @isActive and @currentPopulation is 'NUMER'
-  denominatorIsActive: -> @isActive and @currentPopulation is 'DENOM'
-  exclusionsAreActive: -> @isActive and @currentPopulation is 'DENEX'
-  exceptionsAreActive: -> @isActive and @currentPopulation is 'DENEXCEP'
-  antinumeratorIsActive: -> @isActive and @currentPopulation is 'antinumerator'
+      ippIsActive: @isActive and @currentPopulation is 'IPP'
+      numeratorIsActive: @isActive and @currentPopulation is 'NUMER'
+      denominatorIsActive: @isActive and @currentPopulation is 'DENOM'
+      exclusionsAreActive: @isActive and @currentPopulation is 'DENEX'
+      exceptionsAreActive: @isActive and @currentPopulation is 'DENEXCEP'
+      antinumeratorIsActive: @isActive and @currentPopulation is 'antinumerator'
 
   changeFilter: (event) ->
     @currentPopulation = $(event.currentTarget).data 'population'

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -3,6 +3,29 @@ $circle-bkg-color: #fff;
 $title-circle-radius: 21px;
 
 // Custom styles that are part of the theme
+
+.aggregate-btn {
+  margin-bottom: 15px;
+  width: 100%;
+  background-color: $gray-lighter;
+  text-align: center;
+}
+.aggregate-result {
+  margin-top: -10px; 
+  
+  #aggregate-header {
+    font-weight: 400;
+    font-size: 18px;
+  }
+  
+  #aggregate-value {
+    font-size: 22px;
+    font-weight: 500;
+    color: #4A4A4A;
+  }
+
+}
+
 .user-profile {
   table-layout: fixed;
   width: 80%;

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -59,6 +59,15 @@ class PracticesController < ApplicationController
     end
   end
   
+  def remove_providers
+    practice = Practice.find(params[:id])
+    Provider.where(parent_id: practice.provider.id).delete
+    
+    respond_to do |format|
+      format.html { redirect_to :action => :index }
+    end
+  end
+  
   # DELETE /practices/1
   # DELETE /practices/1.json
   def destroy

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -6,5 +6,6 @@ class Preference
   field :should_display_circle_visual, type: Boolean, default: true
   field :population_chart_scaled_to_IPP, type: Boolean, default: false
   field :should_display_provider_tree, type: Boolean, default: false
+  field :show_aggregate_result, type: Boolean, default: false
   belongs_to :user
 end

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -15,6 +15,7 @@
         <th>Providers</th>
         <th></th>
         <th></th>
+        <th></th>
       </tr>
     </thead>
   <% @practices.each do |practice| %>
@@ -25,7 +26,8 @@
         <td><%= practice.address %></td> 
         <td><%= practice.users ? practice.users.map {|u| u.username}.join(", ") : 'N/A' %></td>                
         <td><%= practice.records ? practice.records.count : 0 %></td>
-        <td><%= practice.provider ? practice.provider.descendants.count : 0 %></td>
+        <td><%= practice.provider ? practice.provider.descendants.count : 'N/A'%></td>
+        <td><%= link_to "Delete Providers", practices_remove_providers_path(id: practice.id), method: :delete, data: { confirm: 'Are you sure you want to delete all providers for ' + "#{practice.name}?"} %></td>
         <td><%= link_to "Delete Patients", practices_remove_patients_path(id: practice.id), method: :delete, data: { confirm: 'Are you sure you want to delete all patients for ' + "#{practice.name}?"} %></td>
         <td><%= link_to 'Delete Practice', practice, method: :delete, data: { confirm: 'Are you sure? There may be patients tied to this practice' } %></td>
       </tr>

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -24,7 +24,7 @@ defaults: &defaults
   enable_map_reduce_rationale: true
   enable_map_reduce_logging: true
   #use provider opml heirarchy instead of practice based system
-  use_opml_structure: true
+  use_opml_structure: false
   #provider type to exclude EH measures from
   eh_exclusion_type: "Division"
   orphan_provider:

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -22,9 +22,9 @@ defaults: &defaults
   force_unsecure_communications: true
   use_map_reduce_prefilter: true
   enable_map_reduce_rationale: true
-  enable_map_reduce_logging: false
+  enable_map_reduce_logging: true
   #use provider opml heirarchy instead of practice based system
-  use_opml_structure: false #true
+  use_opml_structure: true
   #provider type to exclude EH measures from
   eh_exclusion_type: "Division"
   orphan_provider:

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -22,9 +22,9 @@ defaults: &defaults
   force_unsecure_communications: true
   use_map_reduce_prefilter: true
   enable_map_reduce_rationale: true
-  enable_map_reduce_logging: true
+  enable_map_reduce_logging: false
   #use provider opml heirarchy instead of practice based system
-  use_opml_structure: false
+  use_opml_structure: true
   #provider type to exclude EH measures from
   eh_exclusion_type: "Division"
   orphan_provider:

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -24,7 +24,7 @@ defaults: &defaults
   enable_map_reduce_rationale: true
   enable_map_reduce_logging: false
   #use provider opml heirarchy instead of practice based system
-  use_opml_structure: true
+  use_opml_structure: false #true
   #provider type to exclude EH measures from
   eh_exclusion_type: "Division"
   orphan_provider:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ PopHealth::Application.routes.draw do
   
   get 'home/check_authorization'
   delete "practices/remove_patients"
+  delete "practices/remove_providers"
    
   root :to => 'home#index'
 

--- a/lib/hds/record.rb
+++ b/lib/hds/record.rb
@@ -29,7 +29,7 @@ class Record
   
   def self.update_or_create(data, practice_id=nil)
     mrn = data.medical_record_number
-    mrn_p = (practice_id)? mrn + "-" + Practice.all.map{|i| i.id.to_s}.index(practice_id).to_s : ''
+    mrn_p = (practice_id)? mrn + "-" + practice_id : ''
     if practice_id
       existing = Record.where(medical_record_number: mrn_p).first
     else

--- a/lib/hds/record.rb
+++ b/lib/hds/record.rb
@@ -29,7 +29,7 @@ class Record
   
   def self.update_or_create(data, practice_id=nil)
     mrn = data.medical_record_number
-    mrn_p = (practice_id)? mrn + "-" + practice_id : ''
+    mrn_p = (practice_id)? mrn + "_pid_" + practice_id : ''
     if practice_id
       existing = Record.where(medical_record_number: mrn_p).first
     else

--- a/lib/qme/quality_report.rb
+++ b/lib/qme/quality_report.rb
@@ -3,7 +3,7 @@
 module QME
   class QualityReport
 
-
+    field :aggregate_result, type: Integer
 
     # Removes the cached results for the patient with the supplied id and
     # recalculates as necessary

--- a/spec/javascripts/models/user.spec.js.coffee
+++ b/spec/javascripts/models/user.spec.js.coffee
@@ -21,6 +21,11 @@ describe 'User', ->
       @user.save
       expect( @user.get('preferences').should_display_circle_visual).toEqual false
 
+    it 'updates user preferences - show aggregate measure', ->
+      @user.get('preferences').show_aggregate_result = true
+      @user.save
+      expect( @user.get('preferences').show_aggregate_result).toEqual true
+
   describe 'selectedCategories', ->
     it 'returns an empty collection if there are no selected categories', ->
       selectedCategories = @user.selectedCategories(@categories)

--- a/test/functional/api/queries_controller_test.rb
+++ b/test/functional/api/queries_controller_test.rb
@@ -44,8 +44,9 @@ module Api
           q.filters["providers"] = [@provider.id]
           q.save
         end
-      end
-
+        q.aggregate_result = 100
+        q.save!
+      end			
       QME::PatientCache.where({}).each do |pc|
         if pc.value["filters"]
           pc.value["filters"]["providers"] = [@provider.id]
@@ -185,6 +186,9 @@ module Api
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[@provider.id]
       assert_response :success, "admin should be able to create reports for npis "
 
+      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[Provider.root.id]
+      assert_response :success, "admin should be able to create reports for aggregate"
+      
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212
       assert_response :success, "admin should be able to create reports for no npi "
     end
@@ -193,6 +197,9 @@ module Api
       sign_in @staff
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[@provider.id]
       assert_response :success, "staff should be able to create all reports for npis"
+
+      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[Provider.root.id]
+      assert_response :success, "staff should be able to create reports for aggregate"
 
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212
       assert_response 200, "staff should be able to create all reports for no npi"
@@ -214,6 +221,9 @@ module Api
       sign_in @user
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[@provider.id]
       assert_response 403, "Should be unauthorized for npi"
+
+      post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212, :providers=>[Provider.root.id]
+      assert_response 403, "user should not be able to create reports for aggregate"
 
       post :create, :measure_id=>'40280381-3D61-56A7-013E-6649110743CE', :sub_id=>"a", :effective_date=>1212121212
       assert_response 403, "Should be unauthorized with no npi"


### PR DESCRIPTION
Main changes (applicable when configured to use Practice Mode)
- User can view aggregate measure calculation (only the percentage) across all organizations/patients in the popHealth system. To view aggregate, click the 'Show Aggregate Result' button on top of the left panel in the dashboard home page.
- The on/off state of the 'Show Aggregate Result' button will be saved as the user's preference.
- The aggregate measure will only calculate if the 'Show Aggregate Measure' button on the dashboard is selected/turned on.

Other changes
- Format measure results numbers with digit group/comma separators e.g. 12,345
- Sort patient list by last name then first name
- Add provider's patient count to main dashboard page
- Use practice ID as a suffix for patient MRN internally. Will format patient MRN's in patient list page and patient profile page to only show original MRN.
- Text to show 'Loading' for measure calculation
- Remove Providers button in Admin - Practices page
