### PR TITLE
Added mailer config and new bundle workaround

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password, and you can do this through the link below.</p>
 
-<p><%= link_to 'CHANGE', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token) %></p>
+<p><%= link_to 'Change', edit_password_url(@resource, :reset_password_token => @token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -4,4 +4,4 @@
 
 <p>Click the link below to unlock your account:</p>
 
-<p><%= link_to 'UNLOCK', unlock_url(@resource, :unlock_token => @resource.unlock_token) %></p>
+<p><%= link_to 'UNLOCK', unlock_url(@resource, :unlock_token => @token) %></p>

--- a/config/initializers/email.rb
+++ b/config/initializers/email.rb
@@ -1,0 +1,19 @@
+ActionMailer::Base.delivery_method=:smtp
+ActionMailer::Base.smtp_settings = {
+  :address => "smtp.gmail.com",
+  :port => "587",
+  :domain => "gmail.com",
+  :authentication => :login,
+  ## can change to another account
+  :user_name => "",
+  :password => "",
+  :enable_starttls_auto => true
+}
+ActionMailer::Base.perform_deliveries = true 
+ActionMailer::Base.raise_delivery_errors = true 
+ActionMailer::Base.default :charset => "utf-8"
+ActionMailer::Base.default :content_type => "text/html"
+
+## Change IP and port to appropriate server credentials
+ActionMailer::Base.default_url_options[:host] = "192.168.0.211"
+ActionMailer::Base.default_url_options[:port] = 3000

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -21,8 +21,8 @@ defaults: &defaults
   # force the system to allow HTTP connections
   force_unsecure_communications: true
   use_map_reduce_prefilter: true
-  enable_map_reduce_rationale: true
-  enable_map_reduce_logging: true
+  enable_map_reduce_rationale: false
+  enable_map_reduce_logging: false
   #use provider opml heirarchy instead of practice based system
   use_opml_structure: true
   

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -25,6 +25,10 @@ defaults: &defaults
   enable_map_reduce_logging: true
   #use provider opml heirarchy instead of practice based system
   use_opml_structure: true
+  
+  # use workaround for new measure bundle 2.6.0 to get measure results
+  use_new_bundle_workaround: true
+  
   #provider type to exclude EH measures from
   eh_exclusion_type: "Division"
   orphan_provider:

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -27,7 +27,7 @@ defaults: &defaults
   use_opml_structure: true
   
   # use workaround for new measure bundle 2.6.0 to get measure results
-  use_new_bundle_workaround: true
+  ignore_provider_performance_dates: true
   
   #provider type to exclude EH measures from
   eh_exclusion_type: "Division"

--- a/lib/hds/bulk_record_importer.rb
+++ b/lib/hds/bulk_record_importer.rb
@@ -103,7 +103,7 @@ class BulkRecordImporter < HealthDataStandards::Import::BulkRecordImporter
     end
 
 
-    use_new_bundle_workaround = APP_CONFIG['use_new_bundle_workaround']
+    ignore_provider_performance_dates = APP_CONFIG['ignore_provider_performance_dates']
     
     if practice_id
       practice = Practice.find(practice_id)
@@ -115,7 +115,7 @@ class BulkRecordImporter < HealthDataStandards::Import::BulkRecordImporter
       providers.each do |perf|
         prov = perf.provider
         
-        if use_new_bundle_workaround
+        if ignore_provider_performance_dates
           p_start = nil 
           p_end = nil
         else
@@ -185,7 +185,7 @@ class BulkRecordImporter < HealthDataStandards::Import::BulkRecordImporter
     end
     providers.each do |prov|
       prov.provider.ancestors.each do |ancestor|
-        if use_new_bundle_workaround
+        if ignore_provider_performance_dates
           p_start = nil 
           p_end = nil
         else


### PR DESCRIPTION
- Added mailer configuration file. To have a working mailer for password reset/forgot password emails, set the following parameters in the file **config/initializers/email.rb**
  - SMTP settings - address, port, domain, username, password, and authentication method.
  - URL and port # for your popHealth installation
  
- Added a parameter in *config/popHealth.yml* - **'use_new_bundle_workaround'**. The new measure bundles (> 3.5.0) are not always compatible with popHealth's measure calculations; because of some reporting period filter issues with provider performance data, patients are not always included in measure calculations. Setting this variable to **'true'** during installation/setup will adjust the QRDA/CCDA import to make sure all the patients uploaded are included in measure calculations properly.