### PR TITLE
Allow editing practice details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
 script: bundle exec rake test_all
 services:
   - mongodb
+before_install:
+  - gem update bundler
 notifications:
   email:
     recipients:

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -21,6 +21,24 @@ class PracticesController < ApplicationController
     end
   end
 
+  # GET /practices/1
+  # GET /practices/1.json
+  def show
+    @practice = Practice.find(params[:id])
+    @users = User.all.map {|user| [user.username, user.id]}
+    if @practice.nil?
+      respond_to do |format|
+        format.html { redirect_to practices_path, notice: 'A practice with that identifier could not be found.' }
+        format.json { render json: @practice, status: :not_found }
+      end
+    else
+      respond_to do |format|
+        format.html # index.html.erb
+        format.json { render json: @practice }
+      end
+    end
+  end
+  
   # POST /practices
   # POST /practices.json
   def create
@@ -44,6 +62,23 @@ class PracticesController < ApplicationController
     respond_to do |format|
       if @practice.save
         format.html { redirect_to practices_path, notice: 'Practice was successfully created.' }
+        format.json { render json: @practice, status: :created, location: @practice }
+      else
+        format.html { redirect_to practices_path }
+        format.json { render json: @practice.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PUT /practices
+  # PUT /practices.json
+  def update
+    @practice = Practice.find(params[:id])
+    @practice.update_attributes(params[:practice]) unless @practice.nil?
+
+    respond_to do |format|
+      if @practice.save
+        format.html { redirect_to practices_path, notice: 'Practice was successfully updated.' }
         format.json { render json: @practice, status: :created, location: @practice }
       else
         format.html { redirect_to practices_path }

--- a/app/views/practices/_edit_practice.html.erb
+++ b/app/views/practices/_edit_practice.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <h4> Create Practice </h4>
+  <h4> <%= @practice.new_record? ? "Create" : "Edit" %> Practice </h4>
   <table class="table-condensed table-hover">
     <tbody>
       <tr>
@@ -24,12 +24,14 @@
       </tr>
       <tr>
         <td><%= f.label :address %></td>
-        <td><%= f.text_field :address %></td>        
+        <td><%= f.text_area :address %></td>        
       </tr>
+      <% if @practice.new_record? %>
       <tr>
         <td><%= f.label :user, "User" %></td>
         <td><%= select_tag :user, options_for_select(@users), include_blank: true %></td>        
       </tr>
+      <% end %>
       <tr class='pull-right'> <td><%= f.submit class: "btn new-practice-btn"%></td> </tr>
     </tbody>
   </table>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -1,7 +1,7 @@
 <div class="practices">
   <h1>Practices</h1>
   <br/>  
-	<%= render 'new_practice' %>
+  <%= render 'edit_practice' %>
 	<br />
 	<h4> Current Practices </h4>
 	<table class="table">
@@ -16,6 +16,7 @@
         <th></th>
         <th></th>
         <th></th>
+        <th></th>
       </tr>
     </thead>
   <% @practices.each do |practice| %>
@@ -27,6 +28,7 @@
         <td><%= practice.users ? practice.users.map {|u| u.username}.join(", ") : 'N/A' %></td>                
         <td><%= practice.records ? practice.records.count : 0 %></td>
         <td><%= practice.provider ? practice.provider.descendants.count : 'N/A'%></td>
+        <td><%= link_to "Edit Practice", practice_path(practice.id), :class => "btn btn-primary" %></td>
         <td><%= link_to "Delete Providers", practices_remove_providers_path(id: practice.id), method: :delete, data: { confirm: 'Are you sure you want to delete all providers for ' + "#{practice.name}?"} %></td>
         <td><%= link_to "Delete Patients", practices_remove_patients_path(id: practice.id), method: :delete, data: { confirm: 'Are you sure you want to delete all patients for ' + "#{practice.name}?"} %></td>
         <td><%= link_to 'Delete Practice', practice, method: :delete, data: { confirm: 'Are you sure? There may be patients tied to this practice' } %></td>

--- a/app/views/practices/show.html.erb
+++ b/app/views/practices/show.html.erb
@@ -1,0 +1,7 @@
+<div class="practices">
+  <h1>Practices</h1>
+  <br/>  
+  <%= render 'edit_practice' %>
+  <br />
+  <%= link_to 'Back to Practices', practices_path, class: 'btn btn-success' %>
+</div>

--- a/test/functional/practices_controller_test.rb
+++ b/test/functional/practices_controller_test.rb
@@ -29,6 +29,24 @@ class PracticesControllerTest < ActionController::TestCase
     assert_response 403
   end
 
+  test "should show a practice" do
+    sign_in @user
+    get :show, :id => @practice._id
+    assert_response :success
+  end
+
+  test "should raise error when viewing an unknown practice" do
+    sign_in @user
+    assert_raise(Mongoid::Errors::DocumentNotFound) { get :show, :id => 'invalidid' }   # Expect this with default Mongo configuration
+    #assert_redirected_to :action => :index  # Would expect this if you disable Mongo raies_not_found_error
+  end
+
+  test "should not show a practice for non admin" do
+    sign_in @non_user
+    get :show, :id => @practice._id
+    assert_response 403
+  end
+
   test "should create practice" do
     sign_in @user
     
@@ -48,7 +66,28 @@ class PracticesControllerTest < ActionController::TestCase
     end
     assert_response 403
   end
-  
+
+  test "should edit practice" do
+    sign_in @user
+    
+    assert_no_difference('Practice.count') do
+      put :update, id: @practice.id, practice: {:name => 'Updated Organization' }, user: @non_user.id
+    end
+
+    updated_practice = Practice.find(@practice)
+    assert_equal 'Updated Organization', updated_practice.name
+    assert_redirected_to :action => :index
+  end
+
+  test "should not edit practice for non admin" do
+    sign_in @non_user
+    
+    assert_no_difference('Practice.count') do
+      put :update, id: @practice.id, practice: {:name => 'Updated Organization' }, user: @user.id
+    end
+    assert_response 403
+  end
+
   test 'should delete practice' do
     sign_in @user
     


### PR DESCRIPTION
Edit the name, organization and address of a practice.  User was excluded from updates, since multiple users can be associated with a practice.  I believe that should be managed from the Users page.