### PR TITLE
Handle if bundle license is nil

### DIFF
--- a/app/models/bundle.rb
+++ b/app/models/bundle.rb
@@ -11,8 +11,11 @@ class Bundle
   field :extensions, type: Array
 
   def license
-    read_attribute(:license)
-      .gsub(/\\("|')/,'\1') # Remove \ characters from in front of ' or " in the bundle.
-      .gsub(/\\n|",$/,' ') # Remove \n from printing out and get rid of ", at end of bundle, replace with space.
+    license = read_attribute(:license)
+    unless license.nil?
+      license
+        .gsub(/\\("|')/,'\1') # Remove \ characters from in front of ' or " in the bundle.
+        .gsub(/\\n|",$/,' ') # Remove \n from printing out and get rid of ", at end of bundle, replace with space.
+    end
   end
 end

--- a/test/fixtures/bundles/no_license.json
+++ b/test/fixtures/bundles/no_license.json
@@ -1,5 +1,5 @@
 {
-    "title" : null,
+    "title" : "No License",
     "measure_period_start" : null,
     "effective_date" : 1451174400,
     "active" : true,

--- a/test/fixtures/bundles/no_license.json
+++ b/test/fixtures/bundles/no_license.json
@@ -1,0 +1,20 @@
+{
+    "title" : null,
+    "measure_period_start" : null,
+    "effective_date" : 1451174400,
+    "active" : true,
+    "bundle_format" : "3.0.0",
+    "smoking_gun_capable" : true,
+    "version" : "1.0",
+    "hqmfjs_libraries_version" : "2.0.0",
+    "license" : null,
+    "measures" : [],
+    "patients" : [],
+    "exported" : "2015-11-09",
+    "extensions" : [ 
+        "map_reduce_utils", 
+        "hqmf_utils"
+    ],
+    "updated_at" : "2015-11-10T19:04:30.472Z",
+    "created_at" : "2015-11-10T19:04:30.472Z"
+}

--- a/test/fixtures/bundles/with_license.json
+++ b/test/fixtures/bundles/with_license.json
@@ -1,0 +1,20 @@
+{
+    "title" : null,
+    "measure_period_start" : null,
+    "effective_date" : 1451174400,
+    "active" : true,
+    "bundle_format" : "3.0.0",
+    "smoking_gun_capable" : true,
+    "version" : "1.0",
+    "hqmfjs_libraries_version" : "2.0.0",
+    "license" : "Test license with \"text\"\\nand \ndifferent newlines",
+    "measures" : [],
+    "patients" : [],
+    "exported" : "2015-11-09",
+    "extensions" : [ 
+        "map_reduce_utils", 
+        "hqmf_utils"
+    ],
+    "updated_at" : "2015-11-10T19:04:30.472Z",
+    "created_at" : "2015-11-10T19:04:30.472Z"
+}

--- a/test/fixtures/bundles/with_license.json
+++ b/test/fixtures/bundles/with_license.json
@@ -1,5 +1,5 @@
 {
-    "title" : null,
+    "title" : "With License",
     "measure_period_start" : null,
     "effective_date" : 1451174400,
     "active" : true,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,7 @@ class ActiveSupport::TestCase
     db['records'].drop
     db['patient_cache'].drop
     db['query_cache'].drop
+    db['bundles'].drop
   end
 
   def load_code_sets

--- a/test/unit/models/bundle_test.rb
+++ b/test/unit/models/bundle_test.rb
@@ -8,10 +8,10 @@ class BundleTest < ActiveSupport::TestCase
   end
 
   test "should format license text if set" do
-    bundle = Bundle.first
+    bundle = Bundle.find_by(title: "No License")
     assert_nil bundle.license
 
-    bundle = Bundle.last
+    bundle = Bundle.find_by(title: "With License")
     assert_equal "Test license with \"text\" and \ndifferent newlines", bundle.license
   end
   

--- a/test/unit/models/bundle_test.rb
+++ b/test/unit/models/bundle_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class BundleTest < ActiveSupport::TestCase
+
+  setup do
+    dump_database
+    collection_fixtures 'bundles'
+  end
+
+  test "should format license text if set" do
+    bundle = Bundle.first
+    assert_nil bundle.license
+
+    bundle = Bundle.last
+    assert_equal "Test license with \"text\" and \ndifferent newlines", bundle.license
+  end
+  
+end


### PR DESCRIPTION
Fringe situation, but with custom bundles the license isn't always set and that causes the app to crash when you try and register a new user.  This guards against the crash, while allowing license to still come back as nil from the getter.