### PR TITLE
Add Cobertura reporter to popHealth Coverage reporter.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :test, :develop, :ci do
   gem 'jasmine', '2.0.1'
   gem 'turn', :require => false
   gem 'simplecov', :require => false
+  gem 'simplecov-cobertura', :require => false
   gem 'mocha', :require => false
   gem "unicorn", :platforms => [:ruby, :jruby]
   gem 'minitest', "~> 5.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
     json (1.8.3)
     kgio (2.10.0)
     libv8 (3.16.14.13)
+    libxml-ruby (2.8.0)
     log4r (1.1.10)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
@@ -217,6 +218,9 @@ GEM
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
+    simplecov-cobertura (1.0.2)
+      libxml-ruby (~> 2.7)
+      simplecov (~> 0.8)
     simplecov-html (0.10.0)
     slop (3.6.0)
     spreadsheet (1.0.3)
@@ -305,6 +309,7 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 4.0.2)
   simplecov
+  simplecov-cobertura
   spreadsheet (= 1.0.3)
   sshkit
   therubyracer (~> 0.12.0)
@@ -313,6 +318,3 @@ DEPENDENCIES
   uglifier
   unicorn
   will_paginate
-
-BUNDLED WITH
-   1.10.6

--- a/test/simple_cov.rb
+++ b/test/simple_cov.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'simplecov-cobertura'
 SimpleCov.start 'rails'
 
 class SimpleCov::Formatter::QualityFormatter
@@ -10,4 +11,6 @@ class SimpleCov::Formatter::QualityFormatter
   end
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::QualityFormatter
+SimpleCov.formatters = [
+  SimpleCov::Formatter::QualityFormatter,
+  SimpleCov::Formatter::CoberturaFormatter]


### PR DESCRIPTION
To allow the report the coverage of the popHealth testing to be
parsed and submitted to the OSEHRA Dashboard, the test framework should
use the simplecov-cobertura reporter in addition to the standard
SimpleCov reporter.