### PR TITLE
Exception on forgery detection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery :with => :exception
   layout :layout_by_resource
   before_filter :check_ssl_used
 


### PR DESCRIPTION
It's recommended to use ":with => :exception" in CSRF detection, not default behavior of nil session

Refs:
http://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/
http://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf

Identified using brakeman