### PR TITLE
Fixed d3 causing blank screen without provider tree

### DIFF
--- a/app/assets/javascripts/views/provider_view.js.coffee
+++ b/app/assets/javascripts/views/provider_view.js.coffee
@@ -4,7 +4,10 @@ class Thorax.Views.ProviderView extends Thorax.View
     @dashboardView = new Thorax.Views.Dashboard provider_id: @model.id, collection: new Thorax.Collections.Categories PopHealth.categories, parse: true, datesobj: 
       effectiveDate: PopHealth.currentUser.get 'effective_date'
       effectiveStartDate: PopHealth.currentUser.get 'effective_start_date'
-    if PopHealth.currentUser.shouldDisplayProviderTree() then @providerChart = PopHealth.viz.providerChart()
+    if PopHealth.currentUser.shouldDisplayProviderTree() 
+      @providerChart = PopHealth.viz.providerChart()
+    else
+      @providerChart = null    
     @startDate = PopHealth.currentUser.effectiveDateString(false)
   context: ->
     _(super).extend
@@ -15,7 +18,7 @@ class Thorax.Views.ProviderView extends Thorax.View
   events:
     'click .effective-date-btn' : 'setEffectiveDate'
     rendered: ->
-      if @model.isPopulated()
+      if @model.isPopulated() and @providerChart != null
         d3.select(@el).select("#providerChart").datum(@model.toJSON()).call(@providerChart)
         @$('.node').popover()
     model:


### PR DESCRIPTION
Fixed bug where d3 would cause a blank screen in Chrome & Firefox if user did not opt to display the provider tree.