### PR TITLE
Adding fix for getting patients via API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ branches:
     - master
     - develop
     - improve_patient_load
+    - get_patients

--- a/app/controllers/api/patients_controller.rb
+++ b/app/controllers/api/patients_controller.rb
@@ -35,7 +35,7 @@ module Api
     def index
       records = Record.where(@query)
       validate_record_authorizations(records)
-      respond_with  paginate(api_patients_url,records)
+      render json: paginate(api_patients_url,records)
     end
 
     api :GET, "/patients/:id[?include_results=:include_results]", "Retrieve an individual patient"


### PR DESCRIPTION
Pull request for issue #43 - changes line 38 in /api/patients_controller.rb to "render json: paginate(api_patients_url,records)" to resolve the issue.

![render](https://cloud.githubusercontent.com/assets/11775573/14652687/fe594e0e-063a-11e6-9240-4e3e15f58f05.png)

