### PR TITLE
Fix rendering 403 response

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do |exception|
-    render "public/403", :format=>"html", :status=> 403, :alert => exception.message
+    render :file => "public/403", :format=>"html", :status=> 403, :alert => exception.message
   end
 
   def set_effective_date(effective_date=nil, persist=false)


### PR DESCRIPTION
Newer versions of ActionView (noted in 4.1.15, https://github.com/rails/rails/blob/4-1-stable/actionview/CHANGELOG.md) require explicitly setting if you are
rendering a file, otherwise it interprets the parameter as a template.