### PR TITLE
Update list of "supported" rubies for popHealth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
   - 2.1.2
+  - 2.1.5
+  - 2.1.9
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
 before_install:
   - gem update bundler
 env:


### PR DESCRIPTION
I propose updating the list of ruby versions that are "officially supported" by pophealth.  This just modifies the Travis CI config to remove versions of ruby that are no longer supported:
  https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/
  https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
And adds in the newer versions of 2.1, 2.2 and 2.3.

We are keeping 2.1.2 and 2.1.5 for now because they have been used for some time by popHealth users.  2.1.9 is the official latest 2.1 version, but we have added 2.1.10 to test the two-digit version number.