### PR TITLE
Fixes #47 - QualityReport ext failing w/ new bundler

### DIFF
--- a/config/initializers/patches.rb
+++ b/config/initializers/patches.rb
@@ -1,0 +1,1 @@
+require 'qme_ext/quality_report'

--- a/lib/qme_ext/quality_report.rb
+++ b/lib/qme_ext/quality_report.rb
@@ -1,0 +1,47 @@
+# Extending QualityReport so that updating a single patient can deal with
+# OID dictionaries
+module QME
+  class QualityReport
+    include Mongoid::Document
+
+    field :aggregate_result, type: Integer
+
+    # Removes the cached results for the patient with the supplied id and
+    # recalculates as necessary
+    def self.update_patient_results(id)
+      # TODO: need to wait for any outstanding calculations to complete and then prevent
+      # any new ones from starting until we are done.
+
+      # drop any cached measure result calculations for the modified patient
+      QME::PatientCache.where('value.medical_record_id' => id).destroy()
+      
+      # get a list of cached measure results for a single patient
+      sample_patient =  QME::PatientCache.where({}).first
+      if sample_patient
+        cached_results =  QME::PatientCache.where({'value.patient_id' => sample_patient['value']['patient_id']})
+        
+        # for each cached result (a combination of measure_id, sub_id, effective_date and test_id)
+        cached_results.each do |measure|
+          # recalculate patient_cache value for modified patient
+          value = measure['value']
+          measure_model = QME::QualityMeasure.new(value['measure_id'], value['sub_id'], value['test_id'])
+          oid_dictionary = OidHelper.generate_oid_dictionary(measure_model)
+          map = QME::MapReduce::Executor.new(value['measure_id'], value['sub_id'],
+            'effective_start_date' => value['effective_start_date'],
+            'effective_date' => value['effective_date'], 'test_id' => value['test_id'],
+            'oid_dictionary' => oid_dictionary)
+          map.map_record_into_measure_groups(id)
+        end
+      end
+      
+      # remove the query totals so they will be recalculated using the new results for
+      # the modified patient
+
+      QME::QualityReport.where({}).each do |qr|
+        measure_model = QME::QualityMeasure.new(qr['measure_id'], qr['sub_id'], qr['test_id'])
+        oid_dictionary = OidHelper.generate_oid_dictionary(measure_model)
+        qr.calculate({"recalculate"=>true, "oid_dictionary" =>oid_dc},true)
+      end
+    end
+  end
+end

--- a/test/fixtures/query_cache/q7.json
+++ b/test/fixtures/query_cache/q7.json
@@ -1,0 +1,150 @@
+{
+  "_id": {
+    "$oid": "523c57e4949d9dd06956b624"
+  },
+  "measure_id": "40280381-3D61-56A7-013E-6649110743CE",
+  "sub_id": "a",
+  "nqf_id": "0036",
+  "population_ids": {
+    "IPP": "ED07A793-9C2B-47C0-B9EB-6AD4A8026A5D",
+    "DENOM": "47260199-F952-48FE-A822-71AFAEACEF9D",
+    "NUMER": "17E39E36-56BB-4AE1-81C4-ADC1475ACC08",
+    "DENEX": "850A5C2F-3191-4342-BD49-58F392A42172"
+  },
+  "effective_date": 1356998340,
+  "filters": {"providers":["9238429386"]},
+  "IPP": 6,
+  "DENOM": 6,
+  "NUMER": 2,
+  "antinumerator": 2,
+  "DENEX": 2,
+  "DENEXCEP": 0,
+  "MSRPOPL": 0,
+  "considered": 6,
+  "execution_time": 0,
+  "supplemental_data": {
+    "IPP": {
+      "RACE": {
+        "1002-5": 6
+      },
+      "ETHNICITY": {
+        "2186-5": 6
+      },
+      "SEX": {
+        "F": 6
+      },
+      "PAYER": {
+        "349": 6
+      }
+    },
+    "DENOM": {
+      "RACE": {
+        "1002-5": 6
+      },
+      "ETHNICITY": {
+        "2186-5": 6
+      },
+      "SEX": {
+        "F": 6
+      },
+      "PAYER": {
+        "349": 6
+      }
+    },
+    "NUMER": {
+      "RACE": {
+        "1002-5": 2
+      },
+      "ETHNICITY": {
+        "2186-5": 2
+      },
+      "SEX": {
+        "F": 2
+      },
+      "PAYER": {
+        "349": 2
+      }
+    },
+    "DENEX": {
+      "RACE": {
+        "1002-5": 2
+      },
+      "ETHNICITY": {
+        "2186-5": 2
+      },
+      "SEX": {
+        "F": 2
+      },
+      "PAYER": {
+        "349": 2
+      }
+    }
+  },
+  "result" : {"IPP": 6,
+  "DENOM": 6,
+  "NUMER": 2,
+  "antinumerator": 2,
+  "DENEX": 2,
+  "DENEXCEP": 0,
+  "MSRPOPL": 0,
+  "considered": 6,
+  "execution_time": 0,
+  "supplemental_data": {
+    "IPP": {
+      "RACE": {
+        "1002-5": 6
+      },
+      "ETHNICITY": {
+        "2186-5": 6
+      },
+      "SEX": {
+        "F": 6
+      },
+      "PAYER": {
+        "349": 6
+      }
+    },
+    "DENOM": {
+      "RACE": {
+        "1002-5": 6
+      },
+      "ETHNICITY": {
+        "2186-5": 6
+      },
+      "SEX": {
+        "F": 6
+      },
+      "PAYER": {
+        "349": 6
+      }
+    },
+    "NUMER": {
+      "RACE": {
+        "1002-5": 2
+      },
+      "ETHNICITY": {
+        "2186-5": 2
+      },
+      "SEX": {
+        "F": 2
+      },
+      "PAYER": {
+        "349": 2
+      }
+    },
+    "DENEX": {
+      "RACE": {
+        "1002-5": 2
+      },
+      "ETHNICITY": {
+        "2186-5": 2
+      },
+      "SEX": {
+        "F": 2
+      },
+      "PAYER": {
+        "349": 2
+      }
+    }
+  }}
+}

--- a/test/functional/api/queries_controller_test.rb
+++ b/test/functional/api/queries_controller_test.rb
@@ -54,6 +54,30 @@ module Api
       end
     end
 
+    def set_aggregate_options user_show_agg, use_opml
+      APP_CONFIG['use_opml_structure'] = use_opml
+      @admin.preferences.show_aggregate_result = user_show_agg
+      @admin.save!
+    end
+
+    test "show aggregate" do
+      original_show_agg_result = @admin.preferences.show_aggregate_result
+      original_use_opml = APP_CONFIG['use_opml_structure']
+      begin
+        sign_in @admin
+        set_aggregate_options true, false
+        qr = QME::QualityReport.where({_id: "523c57e4949d9dd06956b624"}).first
+        qr.filters["providers"] = [Provider.root._id.to_s]
+        qr.save!
+
+        get :show, :id =>"523c57e4949d9dd06956b624"
+
+        qr = QME::QualityReport.where({_id: "523c57e4949d9dd06956b624"}).first
+        assert_equal 50, qr.aggregate_result
+      ensure
+        set_aggregate_options original_show_agg_result, original_use_opml
+      end
+    end
 
 
     test "show admin" do


### PR DESCRIPTION
The extension to QME::QualityReport does not work properly with bundler
1.12.5, so we need to restructure how the extension is applied.

Will need to verify that this fixes the issue from #55 as well.