### PR TITLE
Custom Devise error handler to resolve exception

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module PopHealth
     # config.autoload_paths += %W(#{config.root}/extras)
     config.autoload_paths += %W(#{Rails.root}/lib/hds)
     config.autoload_paths += %W(#{Rails.root}/lib/measures)
+    config.autoload_paths += %W(#{Rails.root}/lib/devise)
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -216,6 +216,10 @@ Devise.setup do |config|
   #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
   # end
 
+  config.warden do |manager|
+    manager.failure_app = CustomFailure
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/lib/devise/custom_failure.rb
+++ b/lib/devise/custom_failure.rb
@@ -1,0 +1,10 @@
+class CustomFailure < Devise::FailureApp
+  # We override respond to eliminate recall, which causes errors
+  def respond
+    if http_auth?
+      http_auth
+    else
+      redirect
+    end
+  end
+end


### PR DESCRIPTION
If you enter the wrong login credentials, you get an exception stacktrace which complains about a pathname mismatch in pathname.rb ('/' != '.').  This introduces a custom error handler that skips the "recall" method which is causing this error (recall is not needed).