### PR TITLE
Fixes "Export" button showing above toolbar menu

### DIFF
--- a/app/assets/javascripts/templates/dashboard/index.hbs.erb
+++ b/app/assets/javascripts/templates/dashboard/index.hbs.erb
@@ -53,7 +53,7 @@
           <input class="rescale" type="radio" value="true" name="population_chart_scale" {{#if populationChartScaledToIPP}}checked{{/if}}/>
         </label>
       </div>
-      <div class="dropdown pull-right">
+      <div class="dropdown dropdown-btn pull-right">
         <div class="dropdown-toggle pull-right btn btn-primary" data-toggle="dropdown" href="#">
           <i class="glyphicon glyphicon-download-alt"></i> Export</a>
         </div>

--- a/app/assets/javascripts/templates/measures/submeasure.hbs
+++ b/app/assets/javascripts/templates/measures/submeasure.hbs
@@ -20,7 +20,7 @@
   </li>
   
   {{#unless teamMeasuresIsActive}}
-  <div class="dropdown pull-right">
+  <div class="dropdown dropdown-btn pull-right">
     <div class="dropdown-toggle pull-right btn btn-primary export-patients-btn" data-toggle="dropdown" href="#">
       <i class="glyphicon glyphicon-download-alt"></i> EXPORT PATIENTS
     </div>

--- a/app/assets/stylesheets/_styles.scss
+++ b/app/assets/stylesheets/_styles.scss
@@ -432,3 +432,7 @@ $table-border-color: white;
   margin-left: 20px;
   margin-right: 20px;
 }
+
+.dropdown-btn {
+  z-index: 400 !important;
+}


### PR DESCRIPTION
Addresses a UI quirk where the "Export" and "Export Patients" buttons would appear over the dropdown toolbar menu.