### PR TITLE
We do not need to maintain test_id when reporting period updated

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -22,32 +22,6 @@ class HomeController < ApplicationController
       user.effective_date = Time.gm(year.to_i, month.to_i, day.to_i).to_i
       user.save! 
     end
-
-    start_date = current_user.effective_start_date
-    end_date = current_user.effective_date
-
-    rp = ReportingPeriod.where(start_date: start_date, end_date: end_date).first_or_create
-
-    query = {
-      'encounters' => {
-        '$elemMatch' => { 
-          '$or' => [
-		    {
-			  'start_time' => {'$lte' => end_date},
-			  'end_time' => {'$gte' => start_date}
-		    },
-		    {
-		  	'time' => {'$lte' => end_date,'$gte' => start_date}
-		    }
-          ]
-        }
-      }
-    }
-    
-    Record.where(query).each do |record|
-      record.test_id = rp.id
-      record.save!
-    end
     
     render :json => :set_reporting_period, status: 200
   end


### PR DESCRIPTION
Patient records are updated with a test_id (associated with a measure period) whenever the measure period is updated in the UI.  This appears to be overhead, as test_id is only really used with patient_cache entries.