### PR TITLE
Add enable_csrf_for_apis

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
   include LogsHelper
 
-  protect_from_forgery :with => :exception
+  APP_CONFIG['enable_csrf_for_apis'] ? (protect_from_forgery :with => :exception) :
+                                       (protect_from_forgery unless: -> { request.format.json? })
   layout :layout_by_resource
   before_filter :check_ssl_used
 

--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -31,6 +31,10 @@ defaults: &defaults
 
    # Enable/disable the viewing of the measure baseline report
   show_measure_baseline_report: false
+
+  # Enable/disable csrf for API by default is true
+  enable_csrf_for_apis: true
+
   # Define the ranges to color-code the provider's results in the baseline report
   measure_baseline_ranges:
     good: 70.0


### PR DESCRIPTION
#98 #91 This change will allow to users that only use popHealth API disabled CSRF partially just changing the value of enable csrf_for_apis to false in popHealth.yml file,  by the default this property is true.