### PR TITLE
Use view's race/ethnicity values, not plural collections for filter

### DIFF
--- a/app/assets/javascripts/templates/patients/show.hbs
+++ b/app/assets/javascripts/templates/patients/show.hbs
@@ -49,9 +49,9 @@
         </dl>
         <dl class="dl-horizontal">
           <dt>RACE</dt>
-          <dd>{{races}}</dd>
+          <dd>{{race}}</dd>
           <dt>ETHNICITY</dt>
-          <dd>{{ethnicities}}</dd>
+          <dd>{{ethnicity}}</dd>
           <dt>LANGUAGES</dt>
           <dd>{{languages}}</dd>
           <dt>PROVIDERS</dt>


### PR DESCRIPTION
This should correct the issue where unfiltered views of a patient record have race and ethnicity showing up as blank.  This uses the singular item (race, ethnicity) instead of the plural item used in filtering (races, ethnicities)