### PR TITLE
Rollback PR #101 changes - bug causing multiple providers to be created

### DIFF
--- a/config/popHealth.yml
+++ b/config/popHealth.yml
@@ -31,13 +31,6 @@ defaults: &defaults
   # use workaround for new measure bundle 2.6.0 to get measure results
   ignore_provider_performance_dates: true
 
-  # The number of threads to use for importing patient records.  Note that you may not see
-  # a huge performance gain depending on your setup - given that Mongo locks a collection
-  # for an insert, if most of the activity is inserting into Mongo that will end up being
-  # the bottleneck.  More threads are helpful if you have additional processing that takes
-  # place for each file before it's imported.
-  patient_import_threads: 4
-
    # Enable/disable the viewing of the measure baseline report
   show_measure_baseline_report: false
 

--- a/lib/hds/bulk_record_importer.rb
+++ b/lib/hds/bulk_record_importer.rb
@@ -1,5 +1,4 @@
 require 'fileutils'
-require 'thread'
 
 class BulkRecordImporter < HealthDataStandards::Import::BulkRecordImporter
   def initialize
@@ -11,7 +10,6 @@ class BulkRecordImporter < HealthDataStandards::Import::BulkRecordImporter
       failed_dir ||= File.join(File.dirname(file), "failed")
 
       patient_id_list = nil
-      tasks = Queue.new
       
       Zip::ZipFile.open(file.path) do |zipfile|
         zipfile.entries.each do |entry|
@@ -23,30 +21,9 @@ class BulkRecordImporter < HealthDataStandards::Import::BulkRecordImporter
           end
           next if entry.directory?
           data = zipfile.read(entry.name)
-          tasks << {name: entry.name, data: data, failed_dir: failed_dir, practice: practice}
+          self.import_file(entry.name,data,failed_dir,nil,practice)
         end
       end
-
-      # Build an array of worker threads that will access our thread-safe task queue,
-      # and run the import for each file in the task queue.
-      workers = []
-      APP_CONFIG['patient_import_threads'].to_i.times do
-        workers << Thread.new do
-          until tasks.empty?
-            # To avoid deadlock, we pass true to pop so it throws if the queue is empty.
-            # We ignore the exception, and just use it as an indication that all the work
-            # is done.  Without this the call to pop would just hang until more work shows
-            # up, and this would never finish.
-            row = tasks.pop(true) rescue nil
-            if row
-              self.import_file(row[:name],row[:data],row[:failed_dir],nil,row[:practice])
-            end
-          end
-        end
-      end
-
-      # Process the threads and wait until all are completed before continuing
-      workers.each { |t| t.join }
 
       missing_patients = []
 


### PR DESCRIPTION
A bug was detected in the changes introduced in PR #101.  Because the task being threaded included code to create a new provider (if a provider wasn't found), and this logic wasn't properly synchronized, multiple providers were being created for the same practice when only one should have been.

Rollback the changes in the original PR until a suitable fix can be found and implemented.  Will consider the utility of this code as well, since it was noted that it was helpful only in certain circumstances.