### PR TITLE
Update reports_controller.rb

### DIFF
--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -371,6 +371,8 @@ module Api
       measures = HealthDataStandards::CQM::Measure.where(:hqmf_id.in => measure_ids)
       end_date = params["effective_date"] || current_user.effective_date || Time.gm(2015, 12, 31)
       start_date = params["effective_start_date"] || current_user.effective_start_date || end_date.years_ago(1)
+      end_date = end_date.to_i
+      start_date = start_date.to_i
       render xml: exporter.export(patient, measures, start_date, end_date)
     end
 


### PR DESCRIPTION
For the api call  "/reports/cat1/:id/:measure_ids" added two lines (see below).
  end_date = end_date.to_i
  start_date = start_date.to_i

Those statements make sure that the variables end_date and start_date are integers before calling:
exporter.export(patient, measures, start_date, end_date)

Those two lines are necessary because when passing effective_start_date and effective_date to the api, the returned QRDA cat 1 was missing the template 2.16.840.1.113883.10.20.17.2.1 (Reporting period).

Please, someone, verify those lines of code and let me know if there is a better way of doing it. I'm new to Ruby and I hope I'm not creating a side effect.

Thank you