### PR TITLE
Fixes issue when provider_id is not passed to generate cat1 zip file

### DIFF
--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -113,8 +113,9 @@ module Api
       file = File.new(filepath, 'w')
       measures=HealthDataStandards::CQM::Measure.where(:cms_id => params[:cmsid]).to_a
       patients=[]
-      PatientCache.where('value.measure_id' => measures[0]['hqmf_id'],
-                         'value.provider_performances.provider_id' => BSON::ObjectId(params[:provider_id])).each do |pc|
+      patient_cache = PatientCache.where('value.measure_id' => measures[0]['hqmf_id'])
+      patient_cache = patient_cache.where('value.provider_performances.provider_id' => BSON::ObjectId(params[:provider_id])) if params[:provider_id]
+      patient_cache.each do |pc|
         if !pc['value.manual_exclusion']
           p = Record.find(pc['value.patient_id'])
           authorize! :read, p


### PR DESCRIPTION
According to the documentation the provider_id should be optional when generating a cat 1 zip export via the api/reports_controller. However, it currently throws an error and will not return any results. This patch will no longer include the provider_id in the query if one is not given.