### PR TITLE
there is a bug importing a single qrda cat 1 via api.

### DIFF
--- a/lib/hds/bulk_record_importer.rb
+++ b/lib/hds/bulk_record_importer.rb
@@ -73,6 +73,7 @@ class BulkRecordImporter < HealthDataStandards::Import::BulkRecordImporter
 
   def self.import(xml_data, provider_map = {}, practice_id=nil)
     doc = Nokogiri::XML(xml_data)
+    @hds_record_converter = CQM::Converter::HDSRecord.new
 
     providers = []
     root_element_name = doc.root.name


### PR DESCRIPTION
The variable @hds_record_converter is giving a Nill exception on the "import" function,