### PR TITLE
added _id property to qco

### DIFF
--- a/lib/cypress/expected_results_calculator.rb
+++ b/lib/cypress/expected_results_calculator.rb
@@ -94,7 +94,9 @@ module Cypress
       qco['status']['state'] = "completed"
       qco['supplemental_data'] = qco['result']['supplemental_data']
       qco['filters'] = @filters
-      Mongoid.default_client['query_cache'].insert_one(qco)
+      qco_saved = Mongoid.default_client['query_cache'].insert_one(qco)
+      qco["_id"] = qco_saved.inserted_id.to_s
+      qco_saved
     end
 
     private


### PR DESCRIPTION
The property _id from the create_query_cache_object was not present. 
This patch adds that property.