### PR TITLE
fix solving exception when race/ethnicity is not present

### DIFF
--- a/lib/cypress/expected_results_calculator.rb
+++ b/lib/cypress/expected_results_calculator.rb
@@ -74,10 +74,12 @@ module Cypress
     end
 
     def add_or_increment_code(pop, sup_type, code, single_measure_result_hash)
-      if single_measure_result_hash['supplemental_data'][pop][sup_type][code]
-        single_measure_result_hash['supplemental_data'][pop][sup_type][code] += 1
-      else
-        single_measure_result_hash['supplemental_data'][pop][sup_type][code] = 1
+      if code
+        if single_measure_result_hash['supplemental_data'][pop][sup_type][code]
+         single_measure_result_hash['supplemental_data'][pop][sup_type][code] += 1
+        else
+         single_measure_result_hash['supplemental_data'][pop][sup_type][code] = 1
+        end
       end
     end
 


### PR DESCRIPTION
If the QRDA cat 1 is imported with Race/Ethnicity with nullflavor, Mongodb is throwing an exception. This fix handles those cases.